### PR TITLE
add zig 0.16 support plus various fixes/cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ pub fn main() void {
 }
 
 fn run() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -162,7 +162,7 @@ pub fn main() void {
 }
 
 fn run() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ fn run(io: std.Io, allocator: std.mem.Allocator) !void {
 }
 
 fn greetHandler(
+    _: ?*anyopaque,
+    _: std.Io,
     allocator: std.mem.Allocator,
     args: ?std.json.Value,
 ) mcp.tools.ToolError!mcp.tools.ToolResult {
@@ -263,7 +265,7 @@ Define filesystem boundaries:
 
 ```zig
 client.enableRoots(true);
-try client.addRoot("file:///projects", "Projects");
+try client.addRoot(allocator, "file:///projects", "Projects");
 ```
 
 ### Sampling

--- a/README.md
+++ b/README.md
@@ -106,25 +106,17 @@ exe.root_module.addImport("mcp", mcp_dep.module("mcp"));
 const std = @import("std");
 const mcp = @import("mcp");
 
-pub fn main() void {
-    if (run()) {} else |err| {
+pub fn main(init: std.process.Init) void {
+    run(init.io, init.gpa) catch |err| {
         mcp.reportError(err);
-    }
+    };
 }
 
-fn run() !void {
-    var gpa = std.heap.DebugAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
-
-    // Check for updates
-    _ = mcp.report.checkForUpdates(allocator);
-
+fn run(io: std.Io, allocator: std.mem.Allocator) !void {
     // Create server
-    var server = mcp.Server.init(.{
+    var server: mcp.Server = .init(allocator, .{
         .name = "my-server",
         .version = "1.0.0",
-        .allocator = allocator,
     });
     defer server.deinit();
 
@@ -136,12 +128,12 @@ fn run() !void {
     });
 
     // Run with STDIO transport
-    try server.run(.stdio);
+    try server.run(io, allocator, .stdio);
 }
 
 fn greetHandler(
     allocator: std.mem.Allocator,
-    args: ?std.json.Value
+    args: ?std.json.Value,
 ) mcp.tools.ToolError!mcp.tools.ToolResult {
     const name = mcp.tools.getString(args, "name") orelse "World";
     const message = try std.fmt.allocPrint(allocator, "Hello, {s}!", .{name});
@@ -155,30 +147,25 @@ fn greetHandler(
 const std = @import("std");
 const mcp = @import("mcp");
 
-pub fn main() void {
-    if (run()) {} else |err| {
+pub fn main(init: std.process.Init) void {
+    run(init.io, init.gpa) catch |err| {
         mcp.reportError(err);
-    }
+    };
 }
 
-fn run() !void {
-    var gpa = std.heap.DebugAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
-
-    var client = mcp.Client.init(.{
+fn run(io: std.Io, allocator: std.mem.Allocator) !void {
+    var client: mcp.Client = .init(io, allocator, .{
         .name = "my-client",
         .version = "1.0.0",
-        .allocator = allocator,
     });
-    defer client.deinit();
+    defer client.deinit(allocator);
 
     // Enable capabilities
     client.enableSampling();
     client.enableRoots(true); // Supports list changed notifications
 
     // Add roots
-    try client.addRoot("file:///projects", "Projects");
+    try client.addRoot(allocator, "file:///projects", "Projects");
 }
 ```
 

--- a/docs/api/client.md
+++ b/docs/api/client.md
@@ -18,17 +18,15 @@ Create a new MCP client.
 | ----------- | ------------ | ------------------------- |
 | `name`      | `[]const u8` | Client name (required)    |
 | `version`   | `[]const u8` | Client version (required) |
-| `allocator` | `Allocator`  | Memory allocator          |
 
 **Example:**
 
 ```zig
-var client = mcp.Client.init(.{
+var client: mcp.Client = .init(io, allocator, .{
     .name = "my-client",
     .version = "1.0.0",
-    .allocator = allocator,
 });
-defer client.deinit();
+defer client.deinit(allocator);
 ```
 
 ---
@@ -38,7 +36,7 @@ defer client.deinit();
 ### `Client.deinit`
 
 ```zig
-pub fn deinit(self: *Client) void
+pub fn deinit(self: *Client, allocator: std.mem.Allocator) void
 ```
 
 Clean up client resources and pending state.
@@ -106,7 +104,7 @@ Enable the tasks capability for managing long-running operations.
 ### `Client.addRoot`
 
 ```zig
-pub fn addRoot(self: *Client, uri: []const u8, name: ?[]const u8) !void
+pub fn addRoot(self: *Client, allocator: std.mem.Allocator, uri: []const u8, name: ?[]const u8) !void
 ```
 
 Add a filesystem root.
@@ -119,8 +117,8 @@ Add a filesystem root.
 **Example:**
 
 ```zig
-try client.addRoot("file:///home/user/documents", "Documents");
-try client.addRoot("file:///home/user/projects", "Projects");
+try client.addRoot(allocator, "file:///home/user/documents", "Documents");
+try client.addRoot(allocator, "file:///home/user/projects", "Projects");
 ```
 
 ---
@@ -166,13 +164,13 @@ Enabled capabilities.
 ### `Client.connectStdio`
 
 ```zig
-pub fn connectStdio(self: *Client, command: []const u8, args: []const []const u8) !void
+pub fn connectStdio(self: *Client, io: std.Io, allocator: std.mem.Allocator, command: []const u8, args: []const []const u8) !void
 ```
 
 ### `Client.connectHttp`
 
 ```zig
-pub fn connectHttp(self: *Client, url: []const u8) !void
+pub fn connectHttp(self: *Client, io: std.Io, allocator: std.mem.Allocator, url: []const u8) !void
 ```
 
 ### `Client.setAuthorizationToken`
@@ -196,49 +194,49 @@ All request APIs currently send protocol requests and return `!void`.
 ### Tools
 
 ```zig
-pub fn listTools(self: *Client) !void
-pub fn callTool(self: *Client, name: []const u8, arguments: ?std.json.Value) !void
+pub fn listTools(self: *Client, io: std.Io, allocator: std.mem.Allocator) !void
+pub fn callTool(self: *Client, io: std.Io, allocator: std.mem.Allocator, name: []const u8, arguments: ?std.json.Value) !void
 ```
 
 ### Resources
 
 ```zig
-pub fn listResources(self: *Client) !void
-pub fn readResource(self: *Client, uri: []const u8) !void
-pub fn subscribeResource(self: *Client, uri: []const u8) !void
-pub fn unsubscribeResource(self: *Client, uri: []const u8) !void
-pub fn listResourceTemplates(self: *Client) !void
+pub fn listResources(self: *Client, io: std.Io, allocator: std.mem.Allocator) !void
+pub fn readResource(self: *Client, io: std.Io, allocator: std.mem.Allocator, uri: []const u8) !void
+pub fn subscribeResource(self: *Client, io: std.Io, allocator: std.mem.Allocator, uri: []const u8) !void
+pub fn unsubscribeResource(self: *Client, io: std.Io, allocator: std.mem.Allocator, uri: []const u8) !void
+pub fn listResourceTemplates(self: *Client, io: std.Io, allocator: std.mem.Allocator) !void
 ```
 
 ### Prompts
 
 ```zig
-pub fn listPrompts(self: *Client) !void
-pub fn getPrompt(self: *Client, name: []const u8, arguments: ?std.json.Value) !void
+pub fn listPrompts(self: *Client, io: std.Io, allocator: std.mem.Allocator) !void
+pub fn getPrompt(self: *Client, io: std.Io, allocator: std.mem.Allocator, name: []const u8, arguments: ?std.json.Value) !void
 ```
 
 ### Completion / Logging / Health
 
 ```zig
-pub fn complete(self: *Client, ref: std.json.Value, argument: std.json.Value) !void
-pub fn setLogLevel(self: *Client, level: []const u8) !void
-pub fn ping(self: *Client) !void
+pub fn complete(self: *Client, io: std.Io, allocator: std.mem.Allocator, ref: std.json.Value, argument: std.json.Value) !void
+pub fn setLogLevel(self: *Client, io: std.Io, allocator: std.mem.Allocator, level: []const u8) !void
+pub fn ping(self: *Client, io: std.Io, allocator: std.mem.Allocator) !void
 ```
 
 ### Tasks
 
 ```zig
-pub fn getTask(self: *Client, taskId: []const u8) !void
-pub fn getTaskResult(self: *Client, taskId: []const u8) !void
-pub fn listTasks(self: *Client) !void
-pub fn cancelTask(self: *Client, taskId: []const u8) !void
+pub fn getTask(self: *Client, io: std.Io, allocator: std.mem.Allocator, taskId: []const u8) !void
+pub fn getTaskResult(self: *Client, io: std.Io, allocator: std.mem.Allocator, taskId: []const u8) !void
+pub fn listTasks(self: *Client, io: std.Io, allocator: std.mem.Allocator) !void
+pub fn cancelTask(self: *Client, io: std.Io, allocator: std.mem.Allocator, taskId: []const u8) !void
 ```
 
 ### Notifications
 
 ```zig
-pub fn notifyInitialized(self: *Client) !void
-pub fn notifyRootsChanged(self: *Client) !void
+pub fn notifyInitialized(self: *Client, io: std.Io, allocator: std.mem.Allocator) !void
+pub fn notifyRootsChanged(self: *Client, io: std.Io, allocator: std.mem.Allocator) !void
 ```
 
 ## Complete Example
@@ -247,26 +245,25 @@ pub fn notifyRootsChanged(self: *Client) !void
 const std = @import("std");
 const mcp = @import("mcp");
 
-pub fn main() !void {
-    var gpa = std.heap.DebugAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) void {
+    run(init.io, init.gpa) catch |err| mcp.reportError(err);
+}
 
+fn run(io: std.Io, allocator: std.mem.Allocator) !void {
     // Create client
-    var client = mcp.Client.init(.{
+    var client: mcp.Client = .init(io, allocator, .{
         .name = "full-client",
         .version = "1.0.0",
-        .allocator = allocator,
     });
-    defer client.deinit();
+    defer client.deinit(allocator);
 
     // Enable capabilities
     client.enableRoots(true);
     client.enableSampling();
 
     // Configure roots
-    try client.addRoot("file:///home/user/docs", "Documentation");
-    try client.addRoot("file:///home/user/code", "Source Code");
+    try client.addRoot(allocator, "file:///home/user/docs", "Documentation");
+    try client.addRoot(allocator, "file:///home/user/code", "Source Code");
 
     // Print configuration
     std.debug.print("Client: {s} v{s}\n", .{
@@ -287,7 +284,7 @@ pub fn main() !void {
 ### `Client.connectStdio`
 
 ```zig
-pub fn connectStdio(self: *Client, command: []const u8, args: []const []const u8) !void
+pub fn connectStdio(self: *Client, io: std.Io, allocator: std.mem.Allocator, command: []const u8, args: []const []const u8) !void
 ```
 
 Connect to a server using the STDIO transport. 
@@ -296,7 +293,7 @@ Connect to a server using the STDIO transport.
 ### `Client.connectHttp`
 
 ```zig
-pub fn connectHttp(self: *Client, url: []const u8) !void
+pub fn connectHttp(self: *Client, io: std.Io, allocator: std.mem.Allocator, url: []const u8) !void
 ```
 
 Connect to a server via HTTP transport.
@@ -325,10 +322,10 @@ Disconnects from the server and closes the active transport.
 
 ```zig
 /// Request the list of available tools
-pub fn listTools(self: *Client) !void
+pub fn listTools(self: *Client, io: std.Io, allocator: std.mem.Allocator) !void
 
     // Request operations are currently fire-and-handle-later style
-    try client.listTools();
-    try client.callTool("hello", null);
+    try client.listTools(io, allocator);
+    try client.callTool(io, allocator, "hello", null);
 /// Request the list of available resources
-pub fn listResources(self: *Client) !void
+pub fn listResources(self: *Client, io: std.Io, allocator: std.mem.Allocator) !void

--- a/docs/api/client.md
+++ b/docs/api/client.md
@@ -248,7 +248,7 @@ const std = @import("std");
 const mcp = @import("mcp");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -294,9 +294,11 @@ HTTP mode details:
 const std = @import("std");
 const mcp = @import("mcp");
 
-pub fn main() !void {
-    const allocator = std.heap.page_allocator;
+pub fn main(init: std.process.Init) void {
+    run(init.io, init.gpa) catch |err| mcp.reportError(err);
+}
 
+fn run(_: std.Io, allocator: std.mem.Allocator) !void {
     // Create a request
     const request = mcp.jsonrpc.createRequest(
         .{ .integer = 1 },

--- a/docs/api/server.md
+++ b/docs/api/server.md
@@ -5,7 +5,7 @@
 ## Constructor
 
 ```zig
-pub fn init(config: ServerConfig) Server
+pub fn init(allocator: std.mem.Allocator, config: ServerConfig) Server
 ```
 
 Important `ServerConfig` fields:
@@ -14,7 +14,6 @@ Important `ServerConfig` fields:
 | --- | --- | --- |
 | `name` | `[]const u8` | Required server name |
 | `version` | `[]const u8` | Required server version |
-| `allocator` | `std.mem.Allocator` | Memory allocator |
 | `title` | `?[]const u8` | Optional human-readable title |
 | `description` | `?[]const u8` | Optional description |
 | `instructions` | `?[]const u8` | Optional usage instructions |
@@ -23,7 +22,7 @@ Important `ServerConfig` fields:
 
 ```zig
 pub fn deinit(self: *Server) void
-pub fn run(self: *Server, options: RunOptions) !void
+pub fn run(self: *Server, io: std.Io, allocator: std.mem.Allocator, options: RunOptions) !void
 pub fn runWithTransport(self: *Server, t: mcp.transport.Transport) !void
 ```
 
@@ -74,18 +73,14 @@ pub fn notifyPromptsChanged(self: *Server) !void
 const std = @import("std");
 const mcp = @import("mcp");
 
-pub fn main() void {
-    run() catch |err| mcp.reportError(err);
+pub fn main(init: std.process.Init) void {
+    run(init.io, init.gpa) catch |err| mcp.reportError(err);
 }
 
-fn run() !void {
-    var gpa = std.heap.DebugAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var server = mcp.Server.init(.{
+fn run(io: std.Io, allocator: std.mem.Allocator) !void {
+    var server: mcp.Server = .init(allocator, .{
         .name = "api-example-server",
         .version = "1.0.0",
-        .allocator = gpa.allocator(),
     });
     defer server.deinit();
 
@@ -93,13 +88,13 @@ fn run() !void {
         .name = "ping",
         .description = "Returns pong",
         .handler = struct {
-            fn handler(allocator: std.mem.Allocator, _: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
-                return mcp.tools.textResult(allocator, "pong") catch return mcp.tools.ToolError.OutOfMemory;
+            fn handler(alloc: std.mem.Allocator, _: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
+                return mcp.tools.textResult(alloc, "pong") catch return mcp.tools.ToolError.OutOfMemory;
             }
         }.handler,
     });
 
     server.enableLogging();
-    try server.run(.stdio);
+    try server.run(io, allocator, .stdio);
 }
 ```

--- a/docs/api/server.md
+++ b/docs/api/server.md
@@ -79,7 +79,7 @@ pub fn main() void {
 }
 
 fn run() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
 
     var server = mcp.Server.init(.{

--- a/docs/api/server.md
+++ b/docs/api/server.md
@@ -88,7 +88,7 @@ fn run(io: std.Io, allocator: std.mem.Allocator) !void {
         .name = "ping",
         .description = "Returns pong",
         .handler = struct {
-            fn handler(alloc: std.mem.Allocator, _: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
+            fn handler(_: ?*anyopaque, _: std.Io, alloc: std.mem.Allocator, _: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
                 return mcp.tools.textResult(alloc, "pong") catch return mcp.tools.ToolError.OutOfMemory;
             }
         }.handler,

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -299,7 +299,11 @@ pub const LoggingLevel = enum {
 const std = @import("std");
 const mcp = @import("mcp");
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) void {
+    run(init.io, init.gpa) catch |err| mcp.reportError(err);
+}
+
+fn run(_: std.Io, _: std.mem.Allocator) !void {
     std.debug.print("Root: {s}\n", .{root.uri});
     std.debug.print("Implementation: {s} v{s}\n", .{ impl.name, impl.version });
 }

--- a/docs/examples/calculator-server.md
+++ b/docs/examples/calculator-server.md
@@ -27,7 +27,7 @@ zig build
 The calculator example runs over stdio by default (CI/GitHub Actions friendly). To test with `curl`/HTTP, switch the run mode in `examples/calculator_server.zig` to:
 
 ```zig
-try server.run(.{ .http = .{ .host = "localhost", .port = 8080 } });
+try server.run(io, allocator, .{ .http = .{ .host = "localhost", .port = 8080 } });
 ```
 
 ## HTTP Request Example

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -46,7 +46,7 @@ zig build
 To use custom HTTP transport, switch the run line in `examples/simple_server.zig` from stdio to HTTP and set your host/domain and port, for example:
 
 ```zig
-try server.run(.{ .http = .{ .host = "api.example.com", .port = 8443 } });
+try server.run(io, allocator, .{ .http = .{ .host = "api.example.com", .port = 8443 } });
 ```
 
 ## Testing with an AI Client
@@ -79,7 +79,7 @@ For HTTP transport mode:
 
 ```bash
 # switch run line in source from stdio to HTTP mode and set host/port:
-# try server.run(.{ .http = .{ .host = "localhost", .port = 8080 } });
+# try server.run(io, allocator, .{ .http = .{ .host = "localhost", .port = 8080 } });
 ./zig-out/bin/example-server
 
 curl -X POST http://localhost:8080 \
@@ -114,7 +114,12 @@ examples/
 const std = @import("std");
 const mcp = @import("mcp");
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) void {
+    run(init.io, init.gpa) catch |err| mcp.reportError(err);
+}
+
+fn run(io: std.Io, allocator: std.mem.Allocator) !void {
     // Your code here
+    _ = .{ io, allocator };
 }
 ```

--- a/docs/examples/simple-client.md
+++ b/docs/examples/simple-client.md
@@ -29,7 +29,7 @@ pub fn main() void {
 }
 
 fn run() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/examples/simple-client.md
+++ b/docs/examples/simple-client.md
@@ -22,17 +22,13 @@ This example demonstrates how to:
 const std = @import("std");
 const mcp = @import("mcp");
 
-pub fn main() void {
-    run() catch |err| {
+pub fn main(init: std.process.Init) void {
+    run(init.io, init.gpa) catch |err| {
         mcp.reportError(err);
     };
 }
 
-fn run() !void {
-    var gpa = std.heap.DebugAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
-
+fn run(io: std.Io, allocator: std.mem.Allocator) !void {
     // Get command line args for server path
     const args = try std.process.argsAlloc(allocator);
     defer std.process.argsFree(allocator, args);
@@ -44,13 +40,12 @@ fn run() !void {
     }
 
     // Create client
-    var client = mcp.Client.init(.{
+    var client: mcp.Client = .init(io, allocator, .{
         .name = "simple-client",
         .version = "1.0.0",
         .title = "Simple MCP Client",
-        .allocator = allocator,
     });
-    defer client.deinit();
+    defer client.deinit(allocator);
 
     // Enable capabilities
     client.enableSampling();
@@ -59,17 +54,17 @@ fn run() !void {
     client.enableRoots(true);
 
     // Add some roots
-    try client.addRoot("file:///home/user/documents", "Documents");
-    try client.addRoot("file:///home/user/projects", "Projects");
+    try client.addRoot(allocator, "file:///home/user/documents", "Documents");
+    try client.addRoot(allocator, "file:///home/user/projects", "Projects");
 
     std.debug.print("MCP Client initialized\n", .{});
     std.debug.print("Client: {s} v{s}\n", .{ client.config.name, client.config.version });
     std.debug.print("Roots configured: {d}\n", .{client.roots_list.items.len});
 
     // In a real implementation, you would:
-    // 1. Connect to server: try client.connectStdio(args[1], &.{});
-    // 2. List tools: try client.listTools();
-    // 3. Call tools: try client.callTool("greet", args);
+    // 1. Connect to server: try client.connectStdio(io, allocator, args[1], &.{});
+    // 2. List tools: try client.listTools(io, allocator);
+    // 3. Call tools: try client.callTool(io, allocator, "greet", args);
     // 4. Handle responses in an event loop
 
     std.debug.print("\nTo connect to a server, run:\n", .{});
@@ -91,13 +86,13 @@ fn run() !void {
 For stdio servers:
 
 ```zig
-try client.connectStdio("./zig-out/bin/example-server", &.{});
+try client.connectStdio(io, allocator, "./zig-out/bin/example-server", &.{});
 ```
 
 For HTTP servers:
 
 ```zig
-try client.connectHttp("http://localhost:8080");
+try client.connectHttp(io, allocator, "http://localhost:8080");
 ```
 
 ## Expected Console Output

--- a/docs/examples/simple-server.md
+++ b/docs/examples/simple-server.md
@@ -100,7 +100,7 @@ fn run(io: std.Io, allocator: std.mem.Allocator) !void {
     // try server.run(io, allocator, .{ .http = .{ .host = "localhost", .port = 8080 } });
 }
 
-fn greetHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
+fn greetHandler(_: ?*anyopaque, _: std.Io, allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
     const name = mcp.tools.getString(args, "name") orelse "World";
 
     const greeting = std.fmt.allocPrint(allocator, "Hello, {s}! Welcome to MCP.", .{name}) catch return mcp.tools.ToolError.OutOfMemory;
@@ -108,7 +108,7 @@ fn greetHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.T
     return mcp.tools.textResult(allocator, greeting) catch return mcp.tools.ToolError.OutOfMemory;
 }
 
-fn echoHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
+fn echoHandler(_: ?*anyopaque, _: std.Io, allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
     const message = mcp.tools.getString(args, "message") orelse "No message provided";
 
     // Demonstrate structured result
@@ -119,7 +119,7 @@ fn echoHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.To
     return mcp.tools.structuredResult(allocator, .{ .object = obj }) catch return mcp.tools.ToolError.OutOfMemory;
 }
 
-fn aboutHandler(_: std.mem.Allocator, uri: []const u8) mcp.resources.ResourceError!mcp.resources.ResourceContent {
+fn aboutHandler(_: ?*anyopaque, _: std.Io, _: std.mem.Allocator, uri: []const u8) mcp.resources.ResourceError!mcp.resources.ResourceContent {
     return .{
         .uri = uri,
         .mimeType = "text/plain",
@@ -127,7 +127,7 @@ fn aboutHandler(_: std.mem.Allocator, uri: []const u8) mcp.resources.ResourceErr
     };
 }
 
-fn introduceHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.prompts.PromptError![]const mcp.prompts.PromptMessage {
+fn introduceHandler(_: ?*anyopaque, _: std.Io, allocator: std.mem.Allocator, args: ?std.json.Value) mcp.prompts.PromptError![]const mcp.prompts.PromptMessage {
     const style = mcp.prompts.getStringArg(args, "style") orelse "casual";
     _ = style;
 

--- a/docs/examples/simple-server.md
+++ b/docs/examples/simple-server.md
@@ -30,7 +30,7 @@ pub fn main() void {
 }
 
 fn run() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/examples/simple-server.md
+++ b/docs/examples/simple-server.md
@@ -23,28 +23,23 @@ This example shows how to:
 const std = @import("std");
 const mcp = @import("mcp");
 
-pub fn main() void {
-    run() catch |err| {
+pub fn main(init: std.process.Init) void {
+    run(init.io, init.gpa) catch |err| {
         mcp.reportError(err);
     };
 }
 
-fn run() !void {
-    var gpa = std.heap.DebugAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
-
+fn run(io: std.Io, allocator: std.mem.Allocator) !void {
     // Check for updates in background
-    if (mcp.report.checkForUpdates(allocator)) |t| t.detach();
+    if (mcp.report.checkForUpdates(io, allocator)) |t| t.detach();
 
     // Create server
-    var server = mcp.Server.init(.{
+    var server: mcp.Server = .init(allocator, .{
         .name = "simple-server",
         .version = "1.0.0",
         .title = "Simple MCP Server",
         .description = "A simple example MCP server",
         .instructions = "This server provides basic greeting and echo tools.",
-        .allocator = allocator,
     });
     defer server.deinit();
 
@@ -99,10 +94,10 @@ fn run() !void {
     server.enableTasks();
 
     // Run the server
-    try server.run(.stdio);
+    try server.run(io, allocator, .stdio);
 
     // To run with HTTP transport:
-    // try server.run(.{ .http = .{ .host = "localhost", .port = 8080 } });
+    // try server.run(io, allocator, .{ .http = .{ .host = "localhost", .port = 8080 } });
 }
 
 fn greetHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
@@ -156,7 +151,7 @@ Call greet tool over stdio:
 echo '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"greet","arguments":{"name":"Alice"}}}' | ./zig-out/bin/example-server
 ```
 
-To test HTTP mode, switch `server.run(.stdio)` to HTTP in the source and then run:
+To test HTTP mode, switch `server.run(io, allocator, .stdio)` to HTTP in the source and then run:
 
 ```bash
 curl -X POST http://localhost:8080 \

--- a/docs/examples/weather-server.md
+++ b/docs/examples/weather-server.md
@@ -24,25 +24,20 @@ const mcp = @import("mcp");
 
 const NWS_API_BASE = "https://api.weather.gov";
 
-pub fn main() void {
-    run() catch |err| {
+pub fn main(init: std.process.Init) void {
+    run(init.io, init.gpa) catch |err| {
         mcp.reportError(err);
     };
 }
 
-fn run() !void {
-    var gpa = std.heap.DebugAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
-
+fn run(io: std.Io, allocator: std.mem.Allocator) !void {
     // Create weather server
-    var server = mcp.Server.init(.{
+    var server: mcp.Server = .init(allocator, .{
         .name = "weather-server",
         .version = "1.0.0",
         .title = "Weather Server",
         .description = "Get weather alerts and forecasts for US locations",
         .instructions = "Use get_alerts to check weather alerts for a US state, or get_forecast to get the forecast for a location.",
-        .allocator = allocator,
     });
     defer server.deinit();
 
@@ -96,10 +91,10 @@ fn run() !void {
     server.enableTasks();
 
     // Run the server
-    try server.run(.stdio);
+    try server.run(io, allocator, .stdio);
 
     // To run with HTTP transport:
-    // try server.run(.{ .http = .{ .host = "localhost", .port = 8080 } });
+    // try server.run(io, allocator, .{ .http = .{ .host = "localhost", .port = 8080 } });
 }
 
 fn getAlertsHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {

--- a/docs/examples/weather-server.md
+++ b/docs/examples/weather-server.md
@@ -31,7 +31,7 @@ pub fn main() void {
 }
 
 fn run() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/examples/weather-server.md
+++ b/docs/examples/weather-server.md
@@ -97,7 +97,7 @@ fn run(io: std.Io, allocator: std.mem.Allocator) !void {
     // try server.run(io, allocator, .{ .http = .{ .host = "localhost", .port = 8080 } });
 }
 
-fn getAlertsHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
+fn getAlertsHandler(_: ?*anyopaque, _: std.Io, allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
     const state = mcp.tools.getString(args, "state") orelse {
         return mcp.tools.errorResult(allocator, "Missing required argument: state (two-letter US state code)") catch return mcp.tools.ToolError.OutOfMemory;
     };
@@ -120,7 +120,7 @@ fn getAlertsHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.too
     return mcp.tools.textResult(allocator, result) catch return mcp.tools.ToolError.OutOfMemory;
 }
 
-fn getForecastHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
+fn getForecastHandler(_: ?*anyopaque, _: std.Io, allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
     const lat = mcp.tools.getFloat(args, "latitude") orelse {
         return mcp.tools.errorResult(allocator, "Missing required argument: latitude") catch return mcp.tools.ToolError.OutOfMemory;
     };
@@ -162,7 +162,7 @@ fn getForecastHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.t
     return mcp.tools.textResult(allocator, result) catch return mcp.tools.ToolError.OutOfMemory;
 }
 
-fn weatherInfoHandler(_: std.mem.Allocator, uri: []const u8) mcp.resources.ResourceError!mcp.resources.ResourceContent {
+fn weatherInfoHandler(_: ?*anyopaque, _: std.Io, _: std.mem.Allocator, uri: []const u8) mcp.resources.ResourceError!mcp.resources.ResourceContent {
     return .{
         .uri = uri,
         .mimeType = "text/plain",

--- a/docs/guide/client.md
+++ b/docs/guide/client.md
@@ -154,7 +154,7 @@ pub fn main() void {
 }
 
 fn run() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/guide/client.md
+++ b/docs/guide/client.md
@@ -7,12 +7,11 @@ The `Client` allows you to connect to MCP servers and interact with their capabi
 ```zig
 const mcp = @import("mcp");
 
-var client = mcp.Client.init(.{
+var client: mcp.Client = .init(io, allocator, .{
     .name = "my-client",
     .version = "1.0.0",
-    .allocator = allocator,
 });
-defer client.deinit();
+defer client.deinit(allocator);
 ```
 
 ## Configuration
@@ -21,7 +20,6 @@ defer client.deinit();
 | ----------- | ------------ | ------------------------- |
 | `name`      | `[]const u8` | Client name (required)    |
 | `version`   | `[]const u8` | Client version (required) |
-| `allocator` | `Allocator`  | Memory allocator          |
 
 ## Connecting to a Server
 
@@ -30,17 +28,17 @@ defer client.deinit();
 ### STDIO Transport
 
 ```zig
-try client.connectStdio("path/to/server", &.{});
+try client.connectStdio(io, allocator, "path/to/server", &.{});
 ```
 
 ### HTTP Transport
 
 ```zig
 // Connect to localhost on port 8080
-try client.connectHttp("http://localhost:8080");
+try client.connectHttp(io, allocator, "http://localhost:8080");
 
 // Connect to a custom host and port
-try client.connectHttp("http://192.168.1.50:9000");
+try client.connectHttp(io, allocator, "http://192.168.1.50:9000");
 ```
 
 ## Capabilities
@@ -62,7 +60,7 @@ client.enableSampling();
 ### List Available Tools
 
 ```zig
-const tools = try client.listTools();
+const tools = try client.listTools(io, allocator);
 for (tools) |tool| {
     std.debug.print("Tool: {s}\n", .{tool.name});
 }
@@ -74,7 +72,7 @@ for (tools) |tool| {
 var args = std.json.ObjectMap.init(allocator);
 try args.put("name", .{ .string = "World" });
 
-const result = try client.callTool("greet", .{ .object = args });
+const result = try client.callTool(io, allocator, "greet", .{ .object = args });
 
 for (result.content) |content| {
     if (content == .text) {
@@ -88,7 +86,7 @@ for (result.content) |content| {
 ### List Resources
 
 ```zig
-const resources = try client.listResources();
+const resources = try client.listResources(io, allocator);
 for (resources) |resource| {
     std.debug.print("Resource: {s}\n", .{resource.uri});
 }
@@ -97,7 +95,7 @@ for (resources) |resource| {
 ### Read a Resource
 
 ```zig
-const contents = try client.readResource("file:///data.json");
+const contents = try client.readResource(io, allocator, "file:///data.json");
 for (contents) |content| {
     std.debug.print("Content: {s}\n", .{content.text.text});
 }
@@ -108,7 +106,7 @@ for (contents) |content| {
 ### List Prompts
 
 ```zig
-const prompts = try client.listPrompts();
+const prompts = try client.listPrompts(io, allocator);
 for (prompts) |prompt| {
     std.debug.print("Prompt: {s}\n", .{prompt.name});
 }
@@ -120,7 +118,7 @@ for (prompts) |prompt| {
 var args = std.json.ObjectMap.init(allocator);
 try args.put("topic", .{ .string = "Zig programming" });
 
-const result = try client.getPrompt("summarize", .{ .object = args });
+const result = try client.getPrompt(io, allocator, "summarize", .{ .object = args });
 
 for (result.messages) |message| {
     std.debug.print("[{s}]: {s}\n", .{
@@ -135,8 +133,8 @@ for (result.messages) |message| {
 Roots define the file system areas the client has access to:
 
 ```zig
-try client.addRoot("file:///home/user/project", "Project Root");
-try client.addRoot("file:///home/user/data", "Data Directory");
+try client.addRoot(allocator, "file:///home/user/project", "Project Root");
+try client.addRoot(allocator, "file:///home/user/data", "Data Directory");
 ```
 
 ## Complete Example
@@ -145,41 +143,36 @@ try client.addRoot("file:///home/user/data", "Data Directory");
 const std = @import("std");
 const mcp = @import("mcp");
 
-pub fn main() void {
-    if (run()) {
+pub fn main(init: std.process.Init) void {
+    if (run(init.io, init.gpa)) {
         // Success
     } else |err| {
         mcp.reportError(err);
     }
 }
 
-fn run() !void {
-    var gpa = std.heap.DebugAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
-
-    var client = mcp.Client.init(.{
+fn run(io: std.Io, allocator: std.mem.Allocator) !void {
+    var client: mcp.Client = .init(io, allocator, .{
         .name = "demo-client",
         .version = "1.0.0",
-        .allocator = allocator,
     });
-    defer client.deinit();
+    defer client.deinit(allocator);
 
     // Enable capabilities
     client.enableRoots(true);
 
     // Add roots
-    try client.addRoot("file:///home/user/documents", "Documents");
+    try client.addRoot(allocator, "file:///home/user/documents", "Documents");
 
     // Connect to a server
-    try client.connectStdio("./my-server", &.{});
+    try client.connectStdio(io, allocator, "./my-server", &.{});
 
     // List and call tools
-    const tools = try client.listTools();
+    const tools = try client.listTools(io, allocator);
     std.debug.print("Available tools: {d}\n", .{tools.len});
 
     // Call a tool
-    const result = try client.callTool("hello", null);
+    const result = try client.callTool(io, allocator, "hello", null);
     std.debug.print("Result: {any}\n", .{result});
 }
 ```

--- a/docs/guide/error-handling.md
+++ b/docs/guide/error-handling.md
@@ -291,7 +291,7 @@ To ensure your application is running the latest version of mcp.zig, you can ena
 
 ```zig
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     const allocator = gpa.allocator();
 
     // Check for updates in background

--- a/docs/guide/error-handling.md
+++ b/docs/guide/error-handling.md
@@ -154,7 +154,7 @@ fn handleToolCall(self: *Server, request: Request) !Message {
 ### Validate Early
 
 ```zig
-fn handler(allocator: Allocator, args: ?json.Value) ToolError!ToolResult {
+fn handler(_: ?*anyopaque, _: std.Io, allocator: Allocator, args: ?std.json.Value) mcp.tools.ToolError!ToolResult {
     // Validate all arguments first
     const a = getArg(args, "a") orelse return error.InvalidArguments;
     const b = getArg(args, "b") orelse return error.InvalidArguments;
@@ -168,7 +168,7 @@ fn handler(allocator: Allocator, args: ?json.Value) ToolError!ToolResult {
 ### Provide Helpful Messages
 
 ```zig
-fn handler(allocator: Allocator, args: ?json.Value) ToolError!ToolResult {
+fn handler(_: ?*anyopaque, _: std.Io, allocator: Allocator, args: ?std.json.Value) mcp.tools.ToolError!ToolResult {
     const filename = getStringArg(args, "filename") orelse {
         return .{
             .content = &.{Content.createText("Missing 'filename' argument. Please provide the file to process.")},
@@ -183,7 +183,7 @@ fn handler(allocator: Allocator, args: ?json.Value) ToolError!ToolResult {
 ### Use errdefer for Cleanup
 
 ```zig
-fn handler(allocator: Allocator, args: ?json.Value) ToolError!ToolResult {
+fn handler(_: ?*anyopaque, _: std.Io, allocator: Allocator, args: ?std.json.Value) mcp.tools.ToolError!ToolResult {
     const buffer = try allocator.alloc(u8, 1024);
     errdefer allocator.free(buffer);
 

--- a/docs/guide/error-handling.md
+++ b/docs/guide/error-handling.md
@@ -263,8 +263,8 @@ When building MCP servers or clients, it's recommended to handle top-level error
 Wrap your `main` application logic to catch and report unexpected errors:
 
 ```zig
-pub fn main() void {
-    if (run()) {
+pub fn main(init: std.process.Init) void {
+    if (run(init.io, init.gpa)) {
         // Success
     } else |err| {
         // Report error with instructions and link to issue tracker
@@ -290,13 +290,16 @@ const url = mcp.ISSUES_URL;
 To ensure your application is running the latest version of mcp.zig, you can enable background update checks. This will check GitHub Releases and log a message if a new version is available.
 
 ```zig
-pub fn main() !void {
-    var gpa = std.heap.DebugAllocator(.{}){};
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) void {
+    run(init.io, init.gpa) catch |err| {
+        mcp.reportError(err);
+    };
+}
 
+fn run(io: std.Io, allocator: std.mem.Allocator) !void {
     // Check for updates in background
     // This runs on a separate thread; detach to let it run in background
-    if (mcp.report.checkForUpdates(allocator)) |t| t.detach();
+    if (mcp.report.checkForUpdates(io, allocator)) |t| t.detach();
 
     // Continue with server initialization...
 }

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -19,7 +19,7 @@ In this guide, you'll learn how to:
 
 Before you begin, make sure you have:
 
-- [Zig 0.15.0](https://ziglang.org/download/) or later installed
+- [Zig 0.16.0](https://ziglang.org/download/) or later installed
 - Basic familiarity with Zig programming language
 
 ## Quick Installation
@@ -53,27 +53,22 @@ Here's a minimal example of an MCP server:
 const std = @import("std");
 const mcp = @import("mcp");
 
-pub fn main() void {
+pub fn main(init: std.process.Init) void {
     // Run the application logic
-    run() catch |err| {
+    run(init.io, init.gpa) catch |err| {
         // Report error with link to issue tracker if needed
         mcp.reportError(err);
     };
 }
 
-fn run() !void {
-    var gpa = std.heap.DebugAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
-
+fn run(io: std.Io, allocator: std.mem.Allocator) !void {
     // Check for library updates in background (recommended)
-    if (mcp.report.checkForUpdates(allocator)) |t| t.detach();
+    if (mcp.report.checkForUpdates(io, allocator)) |t| t.detach();
 
     // Create a server
-    var server = mcp.Server.init(.{
+    var server: mcp.Server = .init(allocator, .{
         .name = "hello-server",
         .version = "1.0.0",
-        .allocator = allocator,
     });
     defer server.deinit();
 
@@ -85,7 +80,7 @@ fn run() !void {
     });
 
     // Run the server (blocks until shutdown)
-    try server.run(.stdio);
+    try server.run(io, allocator, .stdio);
 }
 
 fn helloHandler(

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -62,7 +62,7 @@ pub fn main() void {
 }
 
 fn run() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -4,7 +4,7 @@ This guide covers different ways to install and use mcp.zig in your project.
 
 ## Requirements
 
-- **Zig 0.15.0** or later
+- **Zig 0.16.0** or later
 - A Zig project with `build.zig` and `build.zig.zon`
 
 ## Using Zig Package Manager
@@ -94,7 +94,8 @@ Create a simple test file to verify the installation:
 const std = @import("std");
 const mcp = @import("mcp");
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) void {
+    _ = init;
     std.debug.print("mcp.zig version: {s}\n", .{mcp.protocol.VERSION});
     std.debug.print("Installation successful!\n", .{});
 }

--- a/docs/guide/prompts.md
+++ b/docs/guide/prompts.md
@@ -119,7 +119,7 @@ const std = @import("std");
 const mcp = @import("mcp");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/guide/prompts.md
+++ b/docs/guide/prompts.md
@@ -118,15 +118,16 @@ try server.addPrompt(prompt);
 const std = @import("std");
 const mcp = @import("mcp");
 
-pub fn main() !void {
-    var gpa = std.heap.DebugAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) void {
+    run(init.io, init.gpa) catch |err| {
+        mcp.reportError(err);
+    };
+}
 
-    var server = mcp.Server.init(.{
+fn run(io: std.Io, allocator: std.mem.Allocator) !void {
+    var server: mcp.Server = .init(allocator, .{
         .name = "prompt-server",
         .version = "1.0.0",
-        .allocator = allocator,
     });
     defer server.deinit();
 
@@ -152,7 +153,7 @@ pub fn main() !void {
         .handler = generateCodeHandler,
     });
 
-    try server.run(.stdio);
+    try server.run(io, allocator, .stdio);
 }
 
 fn explainHandler(

--- a/docs/guide/resources.md
+++ b/docs/guide/resources.md
@@ -137,7 +137,7 @@ const std = @import("std");
 const mcp = @import("mcp");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/guide/resources.md
+++ b/docs/guide/resources.md
@@ -136,15 +136,16 @@ try server.notifyResourceUpdated("file:///data.json");
 const std = @import("std");
 const mcp = @import("mcp");
 
-pub fn main() !void {
-    var gpa = std.heap.DebugAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) void {
+    run(init.io, init.gpa) catch |err| {
+        mcp.reportError(err);
+    };
+}
 
-    var server = mcp.Server.init(.{
+fn run(io: std.Io, allocator: std.mem.Allocator) !void {
+    var server: mcp.Server = .init(allocator, .{
         .name = "resource-server",
         .version = "1.0.0",
-        .allocator = allocator,
     });
     defer server.deinit();
 
@@ -164,7 +165,7 @@ pub fn main() !void {
         .handler = recordHandler,
     });
 
-    try server.run(.stdio);
+    try server.run(io, allocator, .stdio);
 }
 
 fn configHandler(

--- a/docs/guide/schema.md
+++ b/docs/guide/schema.md
@@ -134,10 +134,9 @@ const std = @import("std");
 const mcp = @import("mcp");
 
 pub fn setupServer(allocator: std.mem.Allocator) !mcp.Server {
-    var server = mcp.Server.init(.{
+    var server: mcp.Server = .init(allocator, .{
         .name = "validated-server",
         .version = "1.0.0",
-        .allocator = allocator,
     });
 
     // Build input schema

--- a/docs/guide/server.md
+++ b/docs/guide/server.md
@@ -7,10 +7,9 @@ The Server is the main runtime component for exposing MCP capabilities to AI cli
 ```zig
 const mcp = @import("mcp");
 
-var server = mcp.Server.init(.{
+var server: mcp.Server = .init(allocator, .{
     .name = "my-server",
     .version = "1.0.0",
-    .allocator = allocator,
 });
 defer server.deinit();
 ```
@@ -21,7 +20,6 @@ defer server.deinit();
 | --- | --- | --- |
 | name | []const u8 | Server name (required) |
 | version | []const u8 | Server version (required) |
-| allocator | std.mem.Allocator | Memory allocator |
 | title | ?[]const u8 | Human-readable title |
 | description | ?[]const u8 | Server description |
 | instructions | ?[]const u8 | Optional server usage instructions |
@@ -47,7 +45,7 @@ server.enableTasks();
 For command-line tools and local processes:
 
 ```zig
-try server.run(.stdio);
+try server.run(io, allocator, .stdio);
 ```
 
 ### HTTP Transport
@@ -55,13 +53,13 @@ try server.run(.stdio);
 For remote access:
 
 ```zig
-try server.run(.{ .http = .{ .host = "127.0.0.1", .port = 8080 } });
+try server.run(io, allocator, .{ .http = .{ .host = "127.0.0.1", .port = 8080 } });
 ```
 
 You can also bind custom domains/hosts and ports:
 
 ```zig
-try server.run(.{ .http = .{ .host = "api.example.com", .port = 8443 } });
+try server.run(io, allocator, .{ .http = .{ .host = "api.example.com", .port = 8443 } });
 ```
 
 The HTTP mode accepts JSON-RPC POST requests at the root path.
@@ -119,22 +117,17 @@ fn toolHandler(allocator: Allocator, args: ?json.Value) ToolError!ToolResult {
 const std = @import("std");
 const mcp = @import("mcp");
 
-pub fn main() void {
-    run() catch |err| {
+pub fn main(init: std.process.Init) void {
+    run(init.io, init.gpa) catch |err| {
         mcp.reportError(err);
     };
 }
 
-fn run() !void {
-    var gpa = std.heap.DebugAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
-
-    var server = mcp.Server.init(.{
+fn run(io: std.Io, allocator: std.mem.Allocator) !void {
+    var server: mcp.Server = .init(allocator, .{
         .name = "demo-server",
         .version = "1.0.0",
         .description = "A demo MCP server",
-        .allocator = allocator,
     });
     defer server.deinit();
 
@@ -147,7 +140,7 @@ fn run() !void {
 
     // Run
     server.enableLogging();
-    try server.run(.stdio);
+    try server.run(io, allocator, .stdio);
 }
 
 fn echoHandler(

--- a/docs/guide/server.md
+++ b/docs/guide/server.md
@@ -126,7 +126,7 @@ pub fn main() void {
 }
 
 fn run() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/guide/server.md
+++ b/docs/guide/server.md
@@ -102,7 +102,7 @@ try server.addPrompt(.{
 The server handles errors gracefully:
 
 ```zig
-fn toolHandler(allocator: Allocator, args: ?json.Value) ToolError!ToolResult {
+fn toolHandler(_: ?*anyopaque, _: std.Io, allocator: Allocator, args: ?std.json.Value) mcp.tools.ToolError!ToolResult {
     const message = mcp.tools.getString(args, "message") orelse {
         return mcp.tools.errorResult(allocator, "Missing required argument: message") catch return mcp.tools.ToolError.OutOfMemory;
     };

--- a/docs/guide/tools.md
+++ b/docs/guide/tools.md
@@ -123,7 +123,7 @@ return mcp.tools.errorResult(allocator, "Error occurred");
 ## Error Handling
 
 ```zig
-fn handler(allocator: Allocator, args: ?json.Value) ToolError!ToolResult {
+fn handler(_: ?*anyopaque, _: std.Io, allocator: Allocator, args: ?std.json.Value) mcp.tools.ToolError!ToolResult {
     // Validation error
     if (missing_required_arg) {
         return error.InvalidArguments;

--- a/docs/guide/transport.md
+++ b/docs/guide/transport.md
@@ -16,13 +16,13 @@ The most common transport for local MCP servers.
 ### Server Side
 
 ```zig
-try server.run(.stdio);
+try server.run(io, allocator, .stdio);
 ```
 
 ### Client Side
 
 ```zig
-try client.connectStdio("./my-server", &.{});
+try client.connectStdio(io, allocator, "./my-server", &.{});
 ```
 
 ### How It Works
@@ -46,19 +46,19 @@ For remote MCP servers or web-based integration.
 ### Server Side
 
 ```zig
-try server.run(.{ .http = .{ .port = 8080 } });
+try server.run(io, allocator, .{ .http = .{ .port = 8080 } });
 ```
 
 Custom host/domain and port:
 
 ```zig
-try server.run(.{ .http = .{ .host = "api.example.com", .port = 8443 } });
+try server.run(io, allocator, .{ .http = .{ .host = "api.example.com", .port = 8443 } });
 ```
 
 ### Client Side
 
 ```zig
-try client.connectHttp("http://localhost:8080");
+try client.connectHttp(io, allocator, "http://localhost:8080");
 ```
 
 ### Endpoints
@@ -90,17 +90,11 @@ Implement the `Transport` interface for custom transports:
 
 ```zig
 const MyTransport = struct {
-    allocator: std.mem.Allocator,
-
-    pub fn init(allocator: std.mem.Allocator) MyTransport {
-        return .{ .allocator = allocator };
-    }
-
-    pub fn send(self: *MyTransport, message: []const u8) !void {
+    pub fn send(self: *MyTransport, io: std.Io, allocator: std.mem.Allocator, message: []const u8) !void {
         // Send the message
     }
 
-    pub fn receive(self: *MyTransport) !?[]const u8 {
+    pub fn receive(self: *MyTransport, io: std.Io, allocator: std.mem.Allocator) !?[]const u8 {
         // Receive a message
     }
 
@@ -182,16 +176,17 @@ const message = transport.receive() catch |err| {
 const std = @import("std");
 const mcp = @import("mcp");
 
-pub fn main() !void {
-    var gpa = std.heap.DebugAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) void {
+    run(init.io, init.gpa) catch |err| {
+        mcp.reportError(err);
+    };
+}
 
+fn run(io: std.Io, allocator: std.mem.Allocator) !void {
     // Create server
-    var server = mcp.Server.init(.{
+    var server: mcp.Server = .init(allocator, .{
         .name = "multi-transport-server",
         .version = "1.0.0",
-        .allocator = allocator,
     });
     defer server.deinit();
 
@@ -203,10 +198,10 @@ pub fn main() !void {
 
     if (std.mem.eql(u8, mode, "http")) {
         std.debug.print("Starting HTTP server on port 8080...\n", .{});
-        try server.run(.{ .http = .{ .port = 8080 } });
+        try server.run(io, allocator, .{ .http = .{ .port = 8080 } });
     } else {
         std.debug.print("Starting STDIO server...\n", .{});
-        try server.run(.stdio);
+        try server.run(io, allocator, .stdio);
     }
 }
 ```

--- a/docs/guide/transport.md
+++ b/docs/guide/transport.md
@@ -183,7 +183,7 @@ const std = @import("std");
 const mcp = @import("mcp");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/guide/what-is-mcp.md
+++ b/docs/guide/what-is-mcp.md
@@ -124,7 +124,7 @@ MCP supports multiple transport mechanisms:
 For local process communication (most common):
 
 ```zig
-try server.run(.stdio);
+try server.run(io, allocator, .stdio);
 ```
 
 ### HTTP
@@ -132,7 +132,7 @@ try server.run(.stdio);
 For remote communication:
 
 ```zig
-try server.run(.{ .http = .{ .port = 8080 } });
+try server.run(io, allocator, .{ .http = .{ .port = 8080 } });
 ```
 
 ## Learn More

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,21 +91,16 @@ zig fetch --save https://github.com/muhammad-fiaz/mcp.zig/archive/refs/tags/v0.0
 const std = @import("std");
 const mcp = @import("mcp");
 
-pub fn main() void {
-    run() catch |err| {
+pub fn main(init: std.process.Init) void {
+    run(init.io, init.gpa) catch |err| {
         mcp.reportError(err);
     };
 }
 
-fn run() !void {
-    var gpa = std.heap.DebugAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
-
-    var server = mcp.Server.init(.{
+fn run(io: std.Io, allocator: std.mem.Allocator) !void {
+    var server: mcp.Server = .init(allocator, .{
         .name = "my-server",
         .version = "1.0.0",
-        .allocator = allocator,
     });
     defer server.deinit();
 
@@ -117,7 +112,7 @@ fn run() !void {
     });
 
     // Run with STDIO transport
-    try server.run(.stdio);
+    try server.run(io, allocator, .stdio);
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,7 +98,7 @@ pub fn main() void {
 }
 
 fn run() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/calculator_server.zig
+++ b/examples/calculator_server.zig
@@ -3,19 +3,16 @@
 //! A simple calculator MCP server with arithmetic operations.
 
 const std = @import("std");
+
 const mcp = @import("mcp");
 
-pub fn main() void {
-    run() catch |err| {
+pub fn main(init: std.process.Init) void {
+    run(init.io, init.gpa) catch |err| {
         mcp.reportError(err);
     };
 }
 
-fn run() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
-
+fn run(io: std.Io, allocator: std.mem.Allocator) !void {
     var server = mcp.Server.init(.{
         .name = "calculator-server",
         .version = "1.0.0",
@@ -23,6 +20,7 @@ fn run() !void {
         .description = "Perform arithmetic operations",
         .instructions = "Use add, subtract, multiply, or divide tools with 'a' and 'b' number arguments.",
         .allocator = allocator,
+        .io = io,
     });
     defer server.deinit();
 

--- a/examples/calculator_server.zig
+++ b/examples/calculator_server.zig
@@ -13,15 +13,13 @@ pub fn main(init: std.process.Init) void {
 }
 
 fn run(io: std.Io, allocator: std.mem.Allocator) !void {
-    var server: mcp.Server = .init(.{
+    var server: mcp.Server = .init(allocator, .{
         .name = "calculator-server",
         .version = "1.0.0",
         .title = "Calculator Server",
         .description = "Perform arithmetic operations",
         .instructions = "Use add, subtract, multiply, or divide tools with 'a' and 'b' number arguments.",
-        .allocator = allocator,
-        .io = io,
-    });
+        });
     defer server.deinit();
 
     // Add arithmetic tools
@@ -76,10 +74,10 @@ fn run(io: std.Io, allocator: std.mem.Allocator) !void {
 
     server.enableLogging();
     server.enableTasks();
-    try server.run(.stdio);
+    try server.run(io, allocator, .stdio);
 
     // To run with HTTP transport:
-    // try server.run(.{ .http = .{ .host = "localhost", .port = 8080 } });
+    // try server.run(io, allocator, .{ .http = .{ .host = "localhost", .port = 8080 } });
 }
 
 fn addHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {

--- a/examples/calculator_server.zig
+++ b/examples/calculator_server.zig
@@ -13,7 +13,7 @@ pub fn main(init: std.process.Init) void {
 }
 
 fn run(io: std.Io, allocator: std.mem.Allocator) !void {
-    var server = mcp.Server.init(.{
+    var server: mcp.Server = .init(.{
         .name = "calculator-server",
         .version = "1.0.0",
         .title = "Calculator Server",

--- a/examples/calculator_server.zig
+++ b/examples/calculator_server.zig
@@ -80,7 +80,7 @@ fn run(io: std.Io, allocator: std.mem.Allocator) !void {
     // try server.run(io, allocator, .{ .http = .{ .host = "localhost", .port = 8080 } });
 }
 
-fn addHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
+fn addHandler(_: ?*anyopaque, _: std.Io, allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
     const a = mcp.tools.getFloat(args, "a") orelse {
         return mcp.tools.errorResult(allocator, "Missing argument: a") catch return mcp.tools.ToolError.OutOfMemory;
     };
@@ -93,7 +93,7 @@ fn addHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.Too
     return mcp.tools.textResult(allocator, result) catch return mcp.tools.ToolError.OutOfMemory;
 }
 
-fn subtractHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
+fn subtractHandler(_: ?*anyopaque, _: std.Io, allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
     const a = mcp.tools.getFloat(args, "a") orelse {
         return mcp.tools.errorResult(allocator, "Missing argument: a") catch return mcp.tools.ToolError.OutOfMemory;
     };
@@ -106,7 +106,7 @@ fn subtractHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tool
     return mcp.tools.textResult(allocator, result) catch return mcp.tools.ToolError.OutOfMemory;
 }
 
-fn multiplyHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
+fn multiplyHandler(_: ?*anyopaque, _: std.Io, allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
     const a = mcp.tools.getFloat(args, "a") orelse {
         return mcp.tools.errorResult(allocator, "Missing argument: a") catch return mcp.tools.ToolError.OutOfMemory;
     };
@@ -119,7 +119,7 @@ fn multiplyHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tool
     return mcp.tools.textResult(allocator, result) catch return mcp.tools.ToolError.OutOfMemory;
 }
 
-fn divideHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
+fn divideHandler(_: ?*anyopaque, _: std.Io, allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
     const a = mcp.tools.getFloat(args, "a") orelse {
         return mcp.tools.errorResult(allocator, "Missing argument: a") catch return mcp.tools.ToolError.OutOfMemory;
     };

--- a/examples/simple_client.zig
+++ b/examples/simple_client.zig
@@ -21,14 +21,12 @@ fn run(io: std.Io, allocator: std.mem.Allocator, args: std.process.Args.Vector) 
     }
 
     // Create client
-    var client: mcp.Client = .init(.{
+    var client: mcp.Client = .init(io, allocator, .{
         .name = "simple-client",
         .version = "1.0.0",
         .title = "Simple MCP Client",
-        .allocator = allocator,
-        .io = io,
     });
-    defer client.deinit();
+    defer client.deinit(allocator);
 
     // Enable capabilities
     client.enableSampling();
@@ -37,17 +35,17 @@ fn run(io: std.Io, allocator: std.mem.Allocator, args: std.process.Args.Vector) 
     client.enableRoots(true);
 
     // Add some roots
-    try client.addRoot("file:///home/user/documents", "Documents");
-    try client.addRoot("file:///home/user/projects", "Projects");
+    try client.addRoot(allocator, "file:///home/user/documents", "Documents");
+    try client.addRoot(allocator, "file:///home/user/projects", "Projects");
 
     std.debug.print("MCP Client initialized\n", .{});
     std.debug.print("Client: {s} v{s}\n", .{ client.config.name, client.config.version });
     std.debug.print("Roots configured: {d}\n", .{client.roots_list.items.len});
 
     // In a real implementation, you would:
-    // 1. Connect to server: try client.connectStdio(args[1], &.{});
-    // 2. List tools: try client.listTools();
-    // 3. Call tools: try client.callTool("greet", args);
+    // 1. Connect to server: try client.connectStdio(io, allocator, args[1], &.{});
+    // 2. List tools: try client.listTools(io, allocator);
+    // 3. Call tools: try client.callTool(io, allocator, "greet", args);
     // 4. Handle responses in an event loop
 
     std.debug.print("\nTo connect to a server, run:\n", .{});

--- a/examples/simple_client.zig
+++ b/examples/simple_client.zig
@@ -4,23 +4,16 @@
 //! that connects to a server.
 
 const std = @import("std");
+
 const mcp = @import("mcp");
 
-pub fn main() void {
-    run() catch |err| {
+pub fn main(init: std.process.Init) void {
+    run(init.io, init.gpa, init.minimal.args.vector) catch |err| {
         mcp.reportError(err);
     };
 }
 
-fn run() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
-
-    // Get command line args for server path
-    const args = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, args);
-
+fn run(io: std.Io, allocator: std.mem.Allocator, args: std.process.Args.Vector) !void {
     if (args.len < 2) {
         std.debug.print("Usage: {s} <server-command>\n", .{args[0]});
         std.debug.print("Example: {s} zig-out/bin/example-server\n", .{args[0]});
@@ -28,11 +21,12 @@ fn run() !void {
     }
 
     // Create client
-    var client = mcp.Client.init(.{
+    var client: mcp.Client = .init(.{
         .name = "simple-client",
         .version = "1.0.0",
         .title = "Simple MCP Client",
         .allocator = allocator,
+        .io = io,
     });
     defer client.deinit();
 

--- a/examples/simple_server.zig
+++ b/examples/simple_server.zig
@@ -18,15 +18,13 @@ fn run(io: std.Io, allocator: std.mem.Allocator) !void {
     if (mcp.report.checkForUpdates(io, allocator)) |t| t.detach();
 
     // Create server
-    var server: mcp.Server = .init(.{
+    var server: mcp.Server = .init(allocator, .{
         .name = "simple-server",
         .version = "1.0.0",
         .title = "Simple MCP Server",
         .description = "A simple example MCP server",
         .instructions = "This server provides basic greeting and echo tools.",
-        .allocator = allocator,
-        .io = io,
-    });
+        });
     defer server.deinit();
 
     // Add a greeting tool
@@ -80,10 +78,10 @@ fn run(io: std.Io, allocator: std.mem.Allocator) !void {
     server.enableTasks();
 
     // Run the server
-    try server.run(.stdio);
+    try server.run(io, allocator, .stdio);
 
     // To run with HTTP transport:
-    // try server.run(.{ .http = .{ .host = "localhost", .port = 8080 } });
+    // try server.run(io, allocator, .{ .http = .{ .host = "localhost", .port = 8080 } });
 }
 
 fn greetHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {

--- a/examples/simple_server.zig
+++ b/examples/simple_server.zig
@@ -7,19 +7,15 @@ const std = @import("std");
 
 const mcp = @import("mcp");
 
-pub fn main() void {
-    run() catch |err| {
+pub fn main(init: std.process.Init) void {
+    run(init.io, init.gpa) catch |err| {
         mcp.reportError(err);
     };
 }
 
-fn run() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
-
+fn run(io: std.Io, allocator: std.mem.Allocator) !void {
     // Check for updates in background
-    if (mcp.report.checkForUpdates(allocator)) |t| t.detach();
+    if (mcp.report.checkForUpdates(io, allocator)) |t| t.detach();
 
     // Create server
     var server = mcp.Server.init(.{
@@ -29,6 +25,7 @@ fn run() !void {
         .description = "A simple example MCP server",
         .instructions = "This server provides basic greeting and echo tools.",
         .allocator = allocator,
+        .io = io,
     });
     defer server.deinit();
 
@@ -103,7 +100,7 @@ fn echoHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.To
     // Demonstrate structured result
     var obj: std.json.ObjectMap = .empty;
     obj.put(allocator, "echo", .{ .string = message }) catch {};
-    obj.put(allocator, "timestamp", .{ .integer = std.time.timestamp() }) catch {};
+    obj.put(allocator, "timestamp", .{ .integer = 0 }) catch {};
 
     return mcp.tools.structuredResult(allocator, .{ .object = obj }) catch return mcp.tools.ToolError.OutOfMemory;
 }

--- a/examples/simple_server.zig
+++ b/examples/simple_server.zig
@@ -4,6 +4,7 @@
 //! with tools, resources, and prompts.
 
 const std = @import("std");
+
 const mcp = @import("mcp");
 
 pub fn main() void {
@@ -100,9 +101,9 @@ fn echoHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.To
     const message = mcp.tools.getString(args, "message") orelse "No message provided";
 
     // Demonstrate structured result
-    var obj = std.json.ObjectMap.init(allocator);
-    obj.put("echo", .{ .string = message }) catch {};
-    obj.put("timestamp", .{ .integer = std.time.timestamp() }) catch {};
+    var obj: std.json.ObjectMap = .empty;
+    obj.put(allocator, "echo", .{ .string = message }) catch {};
+    obj.put(allocator, "timestamp", .{ .integer = std.time.timestamp() }) catch {};
 
     return mcp.tools.structuredResult(allocator, .{ .object = obj }) catch return mcp.tools.ToolError.OutOfMemory;
 }

--- a/examples/simple_server.zig
+++ b/examples/simple_server.zig
@@ -84,7 +84,7 @@ fn run(io: std.Io, allocator: std.mem.Allocator) !void {
     // try server.run(io, allocator, .{ .http = .{ .host = "localhost", .port = 8080 } });
 }
 
-fn greetHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
+fn greetHandler(_: ?*anyopaque, _: std.Io, allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
     const name = mcp.tools.getString(args, "name") orelse "World";
 
     const greeting = std.fmt.allocPrint(allocator, "Hello, {s}! Welcome to MCP.", .{name}) catch return mcp.tools.ToolError.OutOfMemory;
@@ -92,7 +92,7 @@ fn greetHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.T
     return mcp.tools.textResult(allocator, greeting) catch return mcp.tools.ToolError.OutOfMemory;
 }
 
-fn echoHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
+fn echoHandler(_: ?*anyopaque, _: std.Io, allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
     const message = mcp.tools.getString(args, "message") orelse "No message provided";
 
     // Demonstrate structured result
@@ -103,7 +103,7 @@ fn echoHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.To
     return mcp.tools.structuredResult(allocator, .{ .object = obj }) catch return mcp.tools.ToolError.OutOfMemory;
 }
 
-fn aboutHandler(_: std.mem.Allocator, uri: []const u8) mcp.resources.ResourceError!mcp.resources.ResourceContent {
+fn aboutHandler(_: ?*anyopaque, _: std.Io, _: std.mem.Allocator, uri: []const u8) mcp.resources.ResourceError!mcp.resources.ResourceContent {
     return .{
         .uri = uri,
         .mimeType = "text/plain",
@@ -111,7 +111,7 @@ fn aboutHandler(_: std.mem.Allocator, uri: []const u8) mcp.resources.ResourceErr
     };
 }
 
-fn introduceHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.prompts.PromptError![]const mcp.prompts.PromptMessage {
+fn introduceHandler(_: ?*anyopaque, _: std.Io, allocator: std.mem.Allocator, args: ?std.json.Value) mcp.prompts.PromptError![]const mcp.prompts.PromptMessage {
     const style = mcp.prompts.getStringArg(args, "style") orelse "casual";
     _ = style;
 

--- a/examples/simple_server.zig
+++ b/examples/simple_server.zig
@@ -18,7 +18,7 @@ fn run(io: std.Io, allocator: std.mem.Allocator) !void {
     if (mcp.report.checkForUpdates(io, allocator)) |t| t.detach();
 
     // Create server
-    var server = mcp.Server.init(.{
+    var server: mcp.Server = .init(.{
         .name = "simple-server",
         .version = "1.0.0",
         .title = "Simple MCP Server",

--- a/examples/weather_server.zig
+++ b/examples/weather_server.zig
@@ -17,7 +17,7 @@ pub fn main(init: std.process.Init) void {
 
 fn run(io: std.Io, allocator: std.mem.Allocator) !void {
     // Create weather server
-    var server = mcp.Server.init(.{
+    var server: mcp.Server = .init(.{
         .name = "weather-server",
         .version = "1.0.0",
         .title = "Weather Server",

--- a/examples/weather_server.zig
+++ b/examples/weather_server.zig
@@ -4,21 +4,18 @@
 //! demonstrating how to create a practical MCP server.
 
 const std = @import("std");
+
 const mcp = @import("mcp");
 
 const NWS_API_BASE = "https://api.weather.gov";
 
-pub fn main() void {
-    run() catch |err| {
+pub fn main(init: std.process.Init) void {
+    run(init.io, init.gpa) catch |err| {
         mcp.reportError(err);
     };
 }
 
-fn run() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
-
+fn run(io: std.Io, allocator: std.mem.Allocator) !void {
     // Create weather server
     var server = mcp.Server.init(.{
         .name = "weather-server",
@@ -27,6 +24,7 @@ fn run() !void {
         .description = "Get weather alerts and forecasts for US locations",
         .instructions = "Use get_alerts to check weather alerts for a US state, or get_forecast to get the forecast for a location.",
         .allocator = allocator,
+        .io = io,
     });
     defer server.deinit();
 

--- a/examples/weather_server.zig
+++ b/examples/weather_server.zig
@@ -82,7 +82,7 @@ fn run(io: std.Io, allocator: std.mem.Allocator) !void {
     // try server.run(io, allocator, .{ .http = .{ .host = "localhost", .port = 8080 } });
 }
 
-fn getAlertsHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
+fn getAlertsHandler(_: ?*anyopaque, _: std.Io, allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
     const state = mcp.tools.getString(args, "state") orelse {
         return mcp.tools.errorResult(allocator, "Missing required argument: state (two-letter US state code)") catch return mcp.tools.ToolError.OutOfMemory;
     };
@@ -109,7 +109,7 @@ fn getAlertsHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.too
     return mcp.tools.textResult(allocator, result) catch return mcp.tools.ToolError.OutOfMemory;
 }
 
-fn getForecastHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
+fn getForecastHandler(_: ?*anyopaque, _: std.Io, allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {
     const lat = mcp.tools.getFloat(args, "latitude") orelse {
         return mcp.tools.errorResult(allocator, "Missing required argument: latitude") catch return mcp.tools.ToolError.OutOfMemory;
     };
@@ -152,7 +152,7 @@ fn getForecastHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.t
     return mcp.tools.textResult(allocator, result) catch return mcp.tools.ToolError.OutOfMemory;
 }
 
-fn weatherInfoHandler(_: std.mem.Allocator, uri: []const u8) mcp.resources.ResourceError!mcp.resources.ResourceContent {
+fn weatherInfoHandler(_: ?*anyopaque, _: std.Io, _: std.mem.Allocator, uri: []const u8) mcp.resources.ResourceError!mcp.resources.ResourceContent {
     return .{
         .uri = uri,
         .mimeType = "text/plain",

--- a/examples/weather_server.zig
+++ b/examples/weather_server.zig
@@ -17,15 +17,13 @@ pub fn main(init: std.process.Init) void {
 
 fn run(io: std.Io, allocator: std.mem.Allocator) !void {
     // Create weather server
-    var server: mcp.Server = .init(.{
+    var server: mcp.Server = .init(allocator, .{
         .name = "weather-server",
         .version = "1.0.0",
         .title = "Weather Server",
         .description = "Get weather alerts and forecasts for US locations",
         .instructions = "Use get_alerts to check weather alerts for a US state, or get_forecast to get the forecast for a location.",
-        .allocator = allocator,
-        .io = io,
-    });
+        });
     defer server.deinit();
 
     // Add get_alerts tool
@@ -78,10 +76,10 @@ fn run(io: std.Io, allocator: std.mem.Allocator) !void {
     server.enableTasks();
 
     // Run the server
-    try server.run(.stdio);
+    try server.run(io, allocator, .stdio);
 
     // To run with HTTP transport:
-    // try server.run(.{ .http = .{ .host = "localhost", .port = 8080 } });
+    // try server.run(io, allocator, .{ .http = .{ .host = "localhost", .port = 8080 } });
 }
 
 fn getAlertsHandler(allocator: std.mem.Allocator, args: ?std.json.Value) mcp.tools.ToolError!mcp.tools.ToolResult {

--- a/src/client/client.zig
+++ b/src/client/client.zig
@@ -6,11 +6,12 @@
 //! Supports task-augmented requests, sampling, elicitation, and roots.
 
 const std = @import("std");
-const protocol = @import("../protocol/protocol.zig");
+
 const jsonrpc = @import("../protocol/jsonrpc.zig");
+const protocol = @import("../protocol/protocol.zig");
 const types = @import("../protocol/types.zig");
-const transport_mod = @import("../transport/transport.zig");
 const report = @import("../report.zig");
+const transport_mod = @import("../transport/transport.zig");
 
 /// Configuration options for creating an MCP client.
 pub const ClientConfig = struct {
@@ -163,55 +164,55 @@ pub const Client = struct {
 
     /// Sends the initialize request to begin the MCP handshake.
     fn initialize(self: *Self) !void {
-        var params = std.json.ObjectMap.init(self.allocator);
-        defer params.deinit();
+        var params: std.json.ObjectMap = .empty;
+        defer params.deinit(self.allocator);
 
-        try params.put("protocolVersion", .{ .string = protocol.VERSION });
+        try params.put(self.allocator, "protocolVersion", .{ .string = protocol.VERSION });
 
-        var caps = std.json.ObjectMap.init(self.allocator);
+        var caps: std.json.ObjectMap = .empty;
         if (self.capabilities.sampling != null) {
-            var sampling_cap = std.json.ObjectMap.init(self.allocator);
+            var sampling_cap: std.json.ObjectMap = .empty;
             if (self.capabilities.sampling.?.context != null) {
-                try sampling_cap.put("context", .{ .object = std.json.ObjectMap.init(self.allocator) });
+                try sampling_cap.put(self.allocator, "context", .{ .object = .empty });
             }
             if (self.capabilities.sampling.?.tools != null) {
-                try sampling_cap.put("tools", .{ .object = std.json.ObjectMap.init(self.allocator) });
+                try sampling_cap.put(self.allocator, "tools", .{ .object = .empty });
             }
-            try caps.put("sampling", .{ .object = sampling_cap });
+            try caps.put(self.allocator, "sampling", .{ .object = sampling_cap });
         }
         if (self.capabilities.roots) |r| {
-            var roots_cap = std.json.ObjectMap.init(self.allocator);
-            try roots_cap.put("listChanged", .{ .bool = r.listChanged });
-            try caps.put("roots", .{ .object = roots_cap });
+            var roots_cap: std.json.ObjectMap = .empty;
+            try roots_cap.put(self.allocator, "listChanged", .{ .bool = r.listChanged });
+            try caps.put(self.allocator, "roots", .{ .object = roots_cap });
         }
         if (self.capabilities.elicitation) |e| {
-            var elicit_cap = std.json.ObjectMap.init(self.allocator);
+            var elicit_cap: std.json.ObjectMap = .empty;
             if (e.form != null) {
-                try elicit_cap.put("form", .{ .object = std.json.ObjectMap.init(self.allocator) });
+                try elicit_cap.put(self.allocator, "form", .{ .object = .empty });
             }
             if (e.url != null) {
-                try elicit_cap.put("url", .{ .object = std.json.ObjectMap.init(self.allocator) });
+                try elicit_cap.put(self.allocator, "url", .{ .object = .empty });
             }
-            try caps.put("elicitation", .{ .object = elicit_cap });
+            try caps.put(self.allocator, "elicitation", .{ .object = elicit_cap });
         }
         if (self.capabilities.tasks != null) {
-            var tasks_cap = std.json.ObjectMap.init(self.allocator);
-            try tasks_cap.put("list", .{ .object = std.json.ObjectMap.init(self.allocator) });
-            try tasks_cap.put("cancel", .{ .object = std.json.ObjectMap.init(self.allocator) });
-            try caps.put("tasks", .{ .object = tasks_cap });
+            var tasks_cap: std.json.ObjectMap = .empty;
+            try tasks_cap.put(self.allocator, "list", .{ .object = .empty });
+            try tasks_cap.put(self.allocator, "cancel", .{ .object = .empty });
+            try caps.put(self.allocator, "tasks", .{ .object = tasks_cap });
         }
-        try params.put("capabilities", .{ .object = caps });
+        try params.put(self.allocator, "capabilities", .{ .object = caps });
 
-        var client_info = std.json.ObjectMap.init(self.allocator);
-        try client_info.put("name", .{ .string = self.config.name });
-        try client_info.put("version", .{ .string = self.config.version });
+        var client_info: std.json.ObjectMap = .empty;
+        try client_info.put(self.allocator, "name", .{ .string = self.config.name });
+        try client_info.put(self.allocator, "version", .{ .string = self.config.version });
         if (self.config.title) |t| {
-            try client_info.put("title", .{ .string = t });
+            try client_info.put(self.allocator, "title", .{ .string = t });
         }
         if (self.config.description) |d| {
-            try client_info.put("description", .{ .string = d });
+            try client_info.put(self.allocator, "description", .{ .string = d });
         }
-        try params.put("clientInfo", .{ .object = client_info });
+        try params.put(self.allocator, "clientInfo", .{ .object = client_info });
 
         try self.sendRequest("initialize", .{ .object = params });
     }
@@ -256,10 +257,10 @@ pub const Client = struct {
 
     /// Invokes a tool on the server with optional arguments.
     pub fn callTool(self: *Self, name: []const u8, arguments: ?std.json.Value) !void {
-        var params = std.json.ObjectMap.init(self.allocator);
-        try params.put("name", .{ .string = name });
+        var params: std.json.ObjectMap = .empty;
+        try params.put(self.allocator, "name", .{ .string = name });
         if (arguments) |args| {
-            try params.put("arguments", args);
+            try params.put(self.allocator, "arguments", args);
         }
         try self.sendRequest("tools/call", .{ .object = params });
     }
@@ -271,22 +272,22 @@ pub const Client = struct {
 
     /// Reads a resource from the server by URI.
     pub fn readResource(self: *Self, uri: []const u8) !void {
-        var params = std.json.ObjectMap.init(self.allocator);
-        try params.put("uri", .{ .string = uri });
+        var params: std.json.ObjectMap = .empty;
+        try params.put(self.allocator, "uri", .{ .string = uri });
         try self.sendRequest("resources/read", .{ .object = params });
     }
 
     /// Subscribes to updates for a resource URI.
     pub fn subscribeResource(self: *Self, uri: []const u8) !void {
-        var params = std.json.ObjectMap.init(self.allocator);
-        try params.put("uri", .{ .string = uri });
+        var params: std.json.ObjectMap = .empty;
+        try params.put(self.allocator, "uri", .{ .string = uri });
         try self.sendRequest("resources/subscribe", .{ .object = params });
     }
 
     /// Unsubscribes from updates for a resource URI.
     pub fn unsubscribeResource(self: *Self, uri: []const u8) !void {
-        var params = std.json.ObjectMap.init(self.allocator);
-        try params.put("uri", .{ .string = uri });
+        var params: std.json.ObjectMap = .empty;
+        try params.put(self.allocator, "uri", .{ .string = uri });
         try self.sendRequest("resources/unsubscribe", .{ .object = params });
     }
 
@@ -302,26 +303,26 @@ pub const Client = struct {
 
     /// Fetches a prompt from the server with optional arguments.
     pub fn getPrompt(self: *Self, name: []const u8, arguments: ?std.json.Value) !void {
-        var params = std.json.ObjectMap.init(self.allocator);
-        try params.put("name", .{ .string = name });
+        var params: std.json.ObjectMap = .empty;
+        try params.put(self.allocator, "name", .{ .string = name });
         if (arguments) |args| {
-            try params.put("arguments", args);
+            try params.put(self.allocator, "arguments", args);
         }
         try self.sendRequest("prompts/get", .{ .object = params });
     }
 
     /// Requests argument completion suggestions.
     pub fn complete(self: *Self, ref: std.json.Value, argument: std.json.Value) !void {
-        var params = std.json.ObjectMap.init(self.allocator);
-        try params.put("ref", ref);
-        try params.put("argument", argument);
+        var params: std.json.ObjectMap = .empty;
+        try params.put(self.allocator, "ref", ref);
+        try params.put(self.allocator, "argument", argument);
         try self.sendRequest("completion/complete", .{ .object = params });
     }
 
     /// Sets the log level on the server.
     pub fn setLogLevel(self: *Self, level: []const u8) !void {
-        var params = std.json.ObjectMap.init(self.allocator);
-        try params.put("level", .{ .string = level });
+        var params: std.json.ObjectMap = .empty;
+        try params.put(self.allocator, "level", .{ .string = level });
         try self.sendRequest("logging/setLevel", .{ .object = params });
     }
 
@@ -332,15 +333,15 @@ pub const Client = struct {
 
     /// Gets the status and metadata of a task.
     pub fn getTask(self: *Self, taskId: []const u8) !void {
-        var params = std.json.ObjectMap.init(self.allocator);
-        try params.put("taskId", .{ .string = taskId });
+        var params: std.json.ObjectMap = .empty;
+        try params.put(self.allocator, "taskId", .{ .string = taskId });
         try self.sendRequest("tasks/get", .{ .object = params });
     }
 
     /// Gets the result payload of a completed task.
     pub fn getTaskResult(self: *Self, taskId: []const u8) !void {
-        var params = std.json.ObjectMap.init(self.allocator);
-        try params.put("taskId", .{ .string = taskId });
+        var params: std.json.ObjectMap = .empty;
+        try params.put(self.allocator, "taskId", .{ .string = taskId });
         try self.sendRequest("tasks/result", .{ .object = params });
     }
 
@@ -351,8 +352,8 @@ pub const Client = struct {
 
     /// Cancels a running task.
     pub fn cancelTask(self: *Self, taskId: []const u8) !void {
-        var params = std.json.ObjectMap.init(self.allocator);
-        try params.put("taskId", .{ .string = taskId });
+        var params: std.json.ObjectMap = .empty;
+        try params.put(self.allocator, "taskId", .{ .string = taskId });
         try self.sendRequest("tasks/cancel", .{ .object = params });
     }
 

--- a/src/client/client.zig
+++ b/src/client/client.zig
@@ -73,7 +73,7 @@ pub const Client = struct {
             .config = config,
             .allocator = allocator,
             .io = io,
-            .pending_requests = std.AutoHashMap(i64, PendingRequest).init(allocator),
+            .pending_requests = .init(allocator),
             .roots_list = .empty,
             .update_thread = report.checkForUpdates(io, allocator),
         };
@@ -142,7 +142,7 @@ pub const Client = struct {
         self.state = .connecting;
 
         const stdio = try self.allocator.create(transport_mod.StdioTransport);
-        stdio.* = transport_mod.StdioTransport.init(self.allocator, self.io.?);
+        stdio.* = .init(self.allocator, self.io.?);
         self.transport = stdio.transport();
 
         try self.initialize();

--- a/src/client/client.zig
+++ b/src/client/client.zig
@@ -22,6 +22,7 @@ pub const ClientConfig = struct {
     icons: ?[]const types.Icon = null,
     websiteUrl: ?[]const u8 = null,
     allocator: std.mem.Allocator = std.heap.page_allocator,
+    io: ?std.Io = null,
 };
 
 /// Connection state of the client.
@@ -40,6 +41,7 @@ pub const ClientState = enum {
 pub const Client = struct {
     config: ClientConfig,
     allocator: std.mem.Allocator,
+    io: std.Io,
     state: ClientState = .disconnected,
     transport: ?transport_mod.Transport = null,
     server_info: ?types.Implementation = null,
@@ -62,12 +64,18 @@ pub const Client = struct {
     /// Initializes a new client with the given configuration.
     pub fn init(config: ClientConfig) Self {
         const allocator = config.allocator;
+        const io = config.io orelse io: {
+            var threaded: std.Io.Threaded = .init_single_threaded;
+            break :io threaded.io();
+        };
+
         return .{
             .config = config,
             .allocator = allocator,
+            .io = io,
             .pending_requests = std.AutoHashMap(i64, PendingRequest).init(allocator),
-            .roots_list = .{},
-            .update_thread = report.checkForUpdates(allocator),
+            .roots_list = .empty,
+            .update_thread = report.checkForUpdates(io, allocator),
         };
     }
 
@@ -134,7 +142,7 @@ pub const Client = struct {
         self.state = .connecting;
 
         const stdio = try self.allocator.create(transport_mod.StdioTransport);
-        stdio.* = transport_mod.StdioTransport.init(self.allocator);
+        stdio.* = transport_mod.StdioTransport.init(self.allocator, self.io.?);
         self.transport = stdio.transport();
 
         try self.initialize();
@@ -377,10 +385,11 @@ pub const Client = struct {
 };
 
 test "Client initialization" {
-    var client = Client.init(.{
+    var client: Client = .init(.{
         .name = "test-client",
         .version = "1.0.0",
         .allocator = std.testing.allocator,
+        .io = std.Io.failing,
     });
     defer client.deinit();
 
@@ -388,10 +397,11 @@ test "Client initialization" {
 }
 
 test "Client capabilities" {
-    var client = Client.init(.{
+    var client: Client = .init(.{
         .name = "test",
         .version = "1.0.0",
         .allocator = std.testing.allocator,
+        .io = std.Io.failing,
     });
     defer client.deinit();
 
@@ -407,10 +417,11 @@ test "Client capabilities" {
 }
 
 test "Client advanced sampling" {
-    var client = Client.init(.{
+    var client: Client = .init(.{
         .name = "test",
         .version = "1.0.0",
         .allocator = std.testing.allocator,
+        .io = std.Io.failing,
     });
     defer client.deinit();
 
@@ -420,10 +431,11 @@ test "Client advanced sampling" {
 }
 
 test "Client add root" {
-    var client = Client.init(.{
+    var client: Client = .init(.{
         .name = "test",
         .version = "1.0.0",
         .allocator = std.testing.allocator,
+        .io = std.Io.failing,
     });
     defer client.deinit();
 

--- a/src/client/client.zig
+++ b/src/client/client.zig
@@ -21,8 +21,6 @@ pub const ClientConfig = struct {
     description: ?[]const u8 = null,
     icons: ?[]const types.Icon = null,
     websiteUrl: ?[]const u8 = null,
-    allocator: std.mem.Allocator = std.heap.page_allocator,
-    io: ?std.Io = null,
 };
 
 /// Connection state of the client.
@@ -40,8 +38,6 @@ pub const ClientState = enum {
 /// reads, prompt fetches, and task management.
 pub const Client = struct {
     config: ClientConfig,
-    allocator: std.mem.Allocator,
-    io: std.Io,
     state: ClientState = .disconnected,
     transport: ?transport_mod.Transport = null,
     server_info: ?types.Implementation = null,
@@ -62,17 +58,9 @@ pub const Client = struct {
     };
 
     /// Initializes a new client with the given configuration.
-    pub fn init(config: ClientConfig) Self {
-        const allocator = config.allocator;
-        const io = config.io orelse io: {
-            var threaded: std.Io.Threaded = .init_single_threaded;
-            break :io threaded.io();
-        };
-
+    pub fn init(io: std.Io, allocator: std.mem.Allocator, config: ClientConfig) Self {
         return .{
             .config = config,
-            .allocator = allocator,
-            .io = io,
             .pending_requests = .init(allocator),
             .roots_list = .empty,
             .update_thread = report.checkForUpdates(io, allocator),
@@ -80,11 +68,11 @@ pub const Client = struct {
     }
 
     /// Releases all resources held by the client.
-    pub fn deinit(self: *Self) void {
+    pub fn deinit(self: *Self, allocator: std.mem.Allocator) void {
         self.pending_requests.deinit();
-        self.roots_list.deinit(self.allocator);
+        self.roots_list.deinit(allocator);
         if (self.authorization_token) |token| {
-            self.allocator.free(token);
+            allocator.free(token);
         }
         if (self.update_thread) |t| t.detach();
     }
@@ -131,113 +119,113 @@ pub const Client = struct {
     }
 
     /// Adds a filesystem root that the server can access.
-    pub fn addRoot(self: *Self, uri: []const u8, name: ?[]const u8) !void {
-        try self.roots_list.append(self.allocator, .{ .uri = uri, .name = name });
+    pub fn addRoot(self: *Self, allocator: std.mem.Allocator, uri: []const u8, name: ?[]const u8) !void {
+        try self.roots_list.append(allocator, .{ .uri = uri, .name = name });
     }
 
     /// Connects to a server by spawning a process and communicating via STDIO.
-    pub fn connectStdio(self: *Self, command: []const u8, args: []const []const u8) !void {
+    pub fn connectStdio(self: *Self, io: std.Io, allocator: std.mem.Allocator, command: []const u8, args: []const []const u8) !void {
         _ = args;
         _ = command;
         self.state = .connecting;
 
-        const stdio = try self.allocator.create(transport_mod.StdioTransport);
-        stdio.* = .init(self.allocator, self.io.?);
+        const stdio = try allocator.create(transport_mod.StdioTransport);
+        stdio.* = .{};
         self.transport = stdio.transport();
 
-        try self.initialize();
+        try self.initialize(io, allocator);
     }
 
     /// Sets the authorization token for Bearer auth (OAuth 2.1).
-    pub fn setAuthorizationToken(self: *Self, token: []const u8) !void {
+    pub fn setAuthorizationToken(self: *Self, allocator: std.mem.Allocator, token: []const u8) !void {
         if (self.authorization_token) |old| {
-            self.allocator.free(old);
+            allocator.free(old);
         }
-        self.authorization_token = try self.allocator.dupe(u8, token);
+        self.authorization_token = try allocator.dupe(u8, token);
     }
 
     /// Connects to a server via HTTP at the specified URL.
-    pub fn connectHttp(self: *Self, url: []const u8) !void {
+    pub fn connectHttp(self: *Self, io: std.Io, allocator: std.mem.Allocator, url: []const u8) !void {
         self.state = .connecting;
 
-        const http = try self.allocator.create(transport_mod.HttpTransport);
-        http.* = try transport_mod.HttpTransport.init(self.allocator, url);
+        const http = try allocator.create(transport_mod.HttpTransport);
+        http.* = try transport_mod.HttpTransport.init(allocator, url);
         if (self.authorization_token) |token| {
-            try http.setAuthorizationToken(token);
+            try http.setAuthorizationToken(allocator, token);
         }
         self.transport = http.transport();
 
-        try self.initialize();
+        try self.initialize(io, allocator);
     }
 
     /// Sends the initialize request to begin the MCP handshake.
-    fn initialize(self: *Self) !void {
+    fn initialize(self: *Self, io: std.Io, allocator: std.mem.Allocator) !void {
         var params: std.json.ObjectMap = .empty;
-        defer params.deinit(self.allocator);
+        defer params.deinit(allocator);
 
-        try params.put(self.allocator, "protocolVersion", .{ .string = protocol.VERSION });
+        try params.put(allocator, "protocolVersion", .{ .string = protocol.VERSION });
 
         var caps: std.json.ObjectMap = .empty;
         if (self.capabilities.sampling != null) {
             var sampling_cap: std.json.ObjectMap = .empty;
             if (self.capabilities.sampling.?.context != null) {
-                try sampling_cap.put(self.allocator, "context", .{ .object = .empty });
+                try sampling_cap.put(allocator, "context", .{ .object = .empty });
             }
             if (self.capabilities.sampling.?.tools != null) {
-                try sampling_cap.put(self.allocator, "tools", .{ .object = .empty });
+                try sampling_cap.put(allocator, "tools", .{ .object = .empty });
             }
-            try caps.put(self.allocator, "sampling", .{ .object = sampling_cap });
+            try caps.put(allocator, "sampling", .{ .object = sampling_cap });
         }
         if (self.capabilities.roots) |r| {
             var roots_cap: std.json.ObjectMap = .empty;
-            try roots_cap.put(self.allocator, "listChanged", .{ .bool = r.listChanged });
-            try caps.put(self.allocator, "roots", .{ .object = roots_cap });
+            try roots_cap.put(allocator, "listChanged", .{ .bool = r.listChanged });
+            try caps.put(allocator, "roots", .{ .object = roots_cap });
         }
         if (self.capabilities.elicitation) |e| {
             var elicit_cap: std.json.ObjectMap = .empty;
             if (e.form != null) {
-                try elicit_cap.put(self.allocator, "form", .{ .object = .empty });
+                try elicit_cap.put(allocator, "form", .{ .object = .empty });
             }
             if (e.url != null) {
-                try elicit_cap.put(self.allocator, "url", .{ .object = .empty });
+                try elicit_cap.put(allocator, "url", .{ .object = .empty });
             }
-            try caps.put(self.allocator, "elicitation", .{ .object = elicit_cap });
+            try caps.put(allocator, "elicitation", .{ .object = elicit_cap });
         }
         if (self.capabilities.tasks != null) {
             var tasks_cap: std.json.ObjectMap = .empty;
-            try tasks_cap.put(self.allocator, "list", .{ .object = .empty });
-            try tasks_cap.put(self.allocator, "cancel", .{ .object = .empty });
-            try caps.put(self.allocator, "tasks", .{ .object = tasks_cap });
+            try tasks_cap.put(allocator, "list", .{ .object = .empty });
+            try tasks_cap.put(allocator, "cancel", .{ .object = .empty });
+            try caps.put(allocator, "tasks", .{ .object = tasks_cap });
         }
-        try params.put(self.allocator, "capabilities", .{ .object = caps });
+        try params.put(allocator, "capabilities", .{ .object = caps });
 
         var client_info: std.json.ObjectMap = .empty;
-        try client_info.put(self.allocator, "name", .{ .string = self.config.name });
-        try client_info.put(self.allocator, "version", .{ .string = self.config.version });
+        try client_info.put(allocator, "name", .{ .string = self.config.name });
+        try client_info.put(allocator, "version", .{ .string = self.config.version });
         if (self.config.title) |t| {
-            try client_info.put(self.allocator, "title", .{ .string = t });
+            try client_info.put(allocator, "title", .{ .string = t });
         }
         if (self.config.description) |d| {
-            try client_info.put(self.allocator, "description", .{ .string = d });
+            try client_info.put(allocator, "description", .{ .string = d });
         }
-        try params.put(self.allocator, "clientInfo", .{ .object = client_info });
+        try params.put(allocator, "clientInfo", .{ .object = client_info });
 
-        try self.sendRequest("initialize", .{ .object = params });
+        try self.sendRequest(io, allocator, "initialize", .{ .object = params });
     }
 
     /// Sends a JSON-RPC request to the connected server.
-    fn sendRequest(self: *Self, method: []const u8, params: ?std.json.Value) !void {
+    fn sendRequest(self: *Self, io: std.Io, allocator: std.mem.Allocator, method: []const u8, params: ?std.json.Value) !void {
         const id = self.next_request_id;
         self.next_request_id += 1;
 
         try self.pending_requests.put(id, .{ .method = method });
 
         const request = jsonrpc.createRequest(.{ .integer = id }, method, params);
-        const json = try jsonrpc.serializeMessage(self.allocator, .{ .request = request });
-        defer self.allocator.free(json);
+        const json = try jsonrpc.serializeMessage(allocator, .{ .request = request });
+        defer allocator.free(json);
 
         if (self.transport) |t| {
-            t.send(json) catch {
+            t.send(io, allocator, json) catch {
                 std.log.err("Failed to send request", .{});
                 return;
             };
@@ -245,13 +233,13 @@ pub const Client = struct {
     }
 
     /// Sends a JSON-RPC notification to the connected server.
-    fn sendNotification(self: *Self, method: []const u8, params: ?std.json.Value) !void {
+    fn sendNotification(self: *Self, io: std.Io, allocator: std.mem.Allocator, method: []const u8, params: ?std.json.Value) !void {
         const notification = jsonrpc.createNotification(method, params);
-        const json = try jsonrpc.serializeMessage(self.allocator, .{ .notification = notification });
-        defer self.allocator.free(json);
+        const json = try jsonrpc.serializeMessage(allocator, .{ .notification = notification });
+        defer allocator.free(json);
 
         if (self.transport) |t| {
-            t.send(json) catch {
+            t.send(io, allocator, json) catch {
                 std.log.err("Failed to send notification", .{});
                 return;
             };
@@ -259,120 +247,120 @@ pub const Client = struct {
     }
 
     /// Requests the list of available tools from the server.
-    pub fn listTools(self: *Self) !void {
-        try self.sendRequest("tools/list", null);
+    pub fn listTools(self: *Self, io: std.Io, allocator: std.mem.Allocator) !void {
+        try self.sendRequest(io, allocator, "tools/list", null);
     }
 
     /// Invokes a tool on the server with optional arguments.
-    pub fn callTool(self: *Self, name: []const u8, arguments: ?std.json.Value) !void {
+    pub fn callTool(self: *Self, io: std.Io, allocator: std.mem.Allocator, name: []const u8, arguments: ?std.json.Value) !void {
         var params: std.json.ObjectMap = .empty;
-        try params.put(self.allocator, "name", .{ .string = name });
+        try params.put(allocator, "name", .{ .string = name });
         if (arguments) |args| {
-            try params.put(self.allocator, "arguments", args);
+            try params.put(allocator, "arguments", args);
         }
-        try self.sendRequest("tools/call", .{ .object = params });
+        try self.sendRequest(io, allocator, "tools/call", .{ .object = params });
     }
 
     /// Requests the list of available resources from the server.
-    pub fn listResources(self: *Self) !void {
-        try self.sendRequest("resources/list", null);
+    pub fn listResources(self: *Self, io: std.Io, allocator: std.mem.Allocator) !void {
+        try self.sendRequest(io, allocator, "resources/list", null);
     }
 
     /// Reads a resource from the server by URI.
-    pub fn readResource(self: *Self, uri: []const u8) !void {
+    pub fn readResource(self: *Self, io: std.Io, allocator: std.mem.Allocator, uri: []const u8) !void {
         var params: std.json.ObjectMap = .empty;
-        try params.put(self.allocator, "uri", .{ .string = uri });
-        try self.sendRequest("resources/read", .{ .object = params });
+        try params.put(allocator, "uri", .{ .string = uri });
+        try self.sendRequest(io, allocator, "resources/read", .{ .object = params });
     }
 
     /// Subscribes to updates for a resource URI.
-    pub fn subscribeResource(self: *Self, uri: []const u8) !void {
+    pub fn subscribeResource(self: *Self, io: std.Io, allocator: std.mem.Allocator, uri: []const u8) !void {
         var params: std.json.ObjectMap = .empty;
-        try params.put(self.allocator, "uri", .{ .string = uri });
-        try self.sendRequest("resources/subscribe", .{ .object = params });
+        try params.put(allocator, "uri", .{ .string = uri });
+        try self.sendRequest(io, allocator, "resources/subscribe", .{ .object = params });
     }
 
     /// Unsubscribes from updates for a resource URI.
-    pub fn unsubscribeResource(self: *Self, uri: []const u8) !void {
+    pub fn unsubscribeResource(self: *Self, io: std.Io, allocator: std.mem.Allocator, uri: []const u8) !void {
         var params: std.json.ObjectMap = .empty;
-        try params.put(self.allocator, "uri", .{ .string = uri });
-        try self.sendRequest("resources/unsubscribe", .{ .object = params });
+        try params.put(allocator, "uri", .{ .string = uri });
+        try self.sendRequest(io, allocator, "resources/unsubscribe", .{ .object = params });
     }
 
     /// Requests the list of resource templates from the server.
-    pub fn listResourceTemplates(self: *Self) !void {
-        try self.sendRequest("resources/templates/list", null);
+    pub fn listResourceTemplates(self: *Self, io: std.Io, allocator: std.mem.Allocator) !void {
+        try self.sendRequest(io, allocator, "resources/templates/list", null);
     }
 
     /// Requests the list of available prompts from the server.
-    pub fn listPrompts(self: *Self) !void {
-        try self.sendRequest("prompts/list", null);
+    pub fn listPrompts(self: *Self, io: std.Io, allocator: std.mem.Allocator) !void {
+        try self.sendRequest(io, allocator, "prompts/list", null);
     }
 
     /// Fetches a prompt from the server with optional arguments.
-    pub fn getPrompt(self: *Self, name: []const u8, arguments: ?std.json.Value) !void {
+    pub fn getPrompt(self: *Self, io: std.Io, allocator: std.mem.Allocator, name: []const u8, arguments: ?std.json.Value) !void {
         var params: std.json.ObjectMap = .empty;
-        try params.put(self.allocator, "name", .{ .string = name });
+        try params.put(allocator, "name", .{ .string = name });
         if (arguments) |args| {
-            try params.put(self.allocator, "arguments", args);
+            try params.put(allocator, "arguments", args);
         }
-        try self.sendRequest("prompts/get", .{ .object = params });
+        try self.sendRequest(io, allocator, "prompts/get", .{ .object = params });
     }
 
     /// Requests argument completion suggestions.
-    pub fn complete(self: *Self, ref: std.json.Value, argument: std.json.Value) !void {
+    pub fn complete(self: *Self, io: std.Io, allocator: std.mem.Allocator, ref: std.json.Value, argument: std.json.Value) !void {
         var params: std.json.ObjectMap = .empty;
-        try params.put(self.allocator, "ref", ref);
-        try params.put(self.allocator, "argument", argument);
-        try self.sendRequest("completion/complete", .{ .object = params });
+        try params.put(allocator, "ref", ref);
+        try params.put(allocator, "argument", argument);
+        try self.sendRequest(io, allocator, "completion/complete", .{ .object = params });
     }
 
     /// Sets the log level on the server.
-    pub fn setLogLevel(self: *Self, level: []const u8) !void {
+    pub fn setLogLevel(self: *Self, io: std.Io, allocator: std.mem.Allocator, level: []const u8) !void {
         var params: std.json.ObjectMap = .empty;
-        try params.put(self.allocator, "level", .{ .string = level });
-        try self.sendRequest("logging/setLevel", .{ .object = params });
+        try params.put(allocator, "level", .{ .string = level });
+        try self.sendRequest(io, allocator, "logging/setLevel", .{ .object = params });
     }
 
     /// Sends a ping to the server.
-    pub fn ping(self: *Self) !void {
-        try self.sendRequest("ping", null);
+    pub fn ping(self: *Self, io: std.Io, allocator: std.mem.Allocator) !void {
+        try self.sendRequest(io, allocator, "ping", null);
     }
 
     /// Gets the status and metadata of a task.
-    pub fn getTask(self: *Self, taskId: []const u8) !void {
+    pub fn getTask(self: *Self, io: std.Io, allocator: std.mem.Allocator, taskId: []const u8) !void {
         var params: std.json.ObjectMap = .empty;
-        try params.put(self.allocator, "taskId", .{ .string = taskId });
-        try self.sendRequest("tasks/get", .{ .object = params });
+        try params.put(allocator, "taskId", .{ .string = taskId });
+        try self.sendRequest(io, allocator, "tasks/get", .{ .object = params });
     }
 
     /// Gets the result payload of a completed task.
-    pub fn getTaskResult(self: *Self, taskId: []const u8) !void {
+    pub fn getTaskResult(self: *Self, io: std.Io, allocator: std.mem.Allocator, taskId: []const u8) !void {
         var params: std.json.ObjectMap = .empty;
-        try params.put(self.allocator, "taskId", .{ .string = taskId });
-        try self.sendRequest("tasks/result", .{ .object = params });
+        try params.put(allocator, "taskId", .{ .string = taskId });
+        try self.sendRequest(io, allocator, "tasks/result", .{ .object = params });
     }
 
     /// Lists all tasks.
-    pub fn listTasks(self: *Self) !void {
-        try self.sendRequest("tasks/list", null);
+    pub fn listTasks(self: *Self, io: std.Io, allocator: std.mem.Allocator) !void {
+        try self.sendRequest(io, allocator, "tasks/list", null);
     }
 
     /// Cancels a running task.
-    pub fn cancelTask(self: *Self, taskId: []const u8) !void {
+    pub fn cancelTask(self: *Self, io: std.Io, allocator: std.mem.Allocator, taskId: []const u8) !void {
         var params: std.json.ObjectMap = .empty;
-        try params.put(self.allocator, "taskId", .{ .string = taskId });
-        try self.sendRequest("tasks/cancel", .{ .object = params });
+        try params.put(allocator, "taskId", .{ .string = taskId });
+        try self.sendRequest(io, allocator, "tasks/cancel", .{ .object = params });
     }
 
     /// Sends the notifications/initialized notification.
-    pub fn notifyInitialized(self: *Self) !void {
-        try self.sendNotification("notifications/initialized", null);
+    pub fn notifyInitialized(self: *Self, io: std.Io, allocator: std.mem.Allocator) !void {
+        try self.sendNotification(io, allocator, "notifications/initialized", null);
     }
 
     /// Sends the notifications/roots/list_changed notification.
-    pub fn notifyRootsChanged(self: *Self) !void {
-        try self.sendNotification("notifications/roots/list_changed", null);
+    pub fn notifyRootsChanged(self: *Self, io: std.Io, allocator: std.mem.Allocator) !void {
+        try self.sendNotification(io, allocator, "notifications/roots/list_changed", null);
     }
 
     /// Disconnects from the server and releases the transport.
@@ -385,25 +373,21 @@ pub const Client = struct {
 };
 
 test "Client initialization" {
-    var client: Client = .init(.{
+    var client: Client = .init(std.Io.failing, std.testing.allocator, .{
         .name = "test-client",
         .version = "1.0.0",
-        .allocator = std.testing.allocator,
-        .io = std.Io.failing,
     });
-    defer client.deinit();
+    defer client.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(ClientState.disconnected, client.state);
 }
 
 test "Client capabilities" {
-    var client: Client = .init(.{
+    var client: Client = .init(std.Io.failing, std.testing.allocator, .{
         .name = "test",
         .version = "1.0.0",
-        .allocator = std.testing.allocator,
-        .io = std.Io.failing,
     });
-    defer client.deinit();
+    defer client.deinit(std.testing.allocator);
 
     client.enableSampling();
     client.enableRoots(true);
@@ -417,13 +401,11 @@ test "Client capabilities" {
 }
 
 test "Client advanced sampling" {
-    var client: Client = .init(.{
+    var client: Client = .init(std.Io.failing, std.testing.allocator, .{
         .name = "test",
         .version = "1.0.0",
-        .allocator = std.testing.allocator,
-        .io = std.Io.failing,
     });
-    defer client.deinit();
+    defer client.deinit(std.testing.allocator);
 
     client.enableSamplingAdvanced(true, true);
     try std.testing.expect(client.capabilities.sampling.?.context != null);
@@ -431,14 +413,12 @@ test "Client advanced sampling" {
 }
 
 test "Client add root" {
-    var client: Client = .init(.{
+    var client: Client = .init(std.Io.failing, std.testing.allocator, .{
         .name = "test",
         .version = "1.0.0",
-        .allocator = std.testing.allocator,
-        .io = std.Io.failing,
     });
-    defer client.deinit();
+    defer client.deinit(std.testing.allocator);
 
-    try client.addRoot("file:///tmp", "Temp");
+    try client.addRoot(std.testing.allocator, "file:///tmp", "Temp");
     try std.testing.expectEqual(@as(usize, 1), client.roots_list.items.len);
 }

--- a/src/protocol/jsonrpc.zig
+++ b/src/protocol/jsonrpc.zig
@@ -5,6 +5,7 @@
 //! for creating requests, responses, notifications, and errors.
 
 const std = @import("std");
+
 const types = @import("types.zig");
 
 /// JSON-RPC protocol version.
@@ -254,7 +255,7 @@ fn parseRequestId(value: std.json.Value) !types.RequestId {
 
 /// Serializes a message to a JSON string.
 pub fn serializeMessage(allocator: std.mem.Allocator, message: Message) ![]u8 {
-    var buffer: std.ArrayList(u8) = .{};
+    var buffer: std.ArrayList(u8) = .empty;
     errdefer buffer.deinit(allocator);
 
     switch (message) {

--- a/src/protocol/schema.zig
+++ b/src/protocol/schema.zig
@@ -82,11 +82,10 @@ pub const Schema = struct {
 /// Builder for creating JSON schemas programmatically.
 pub const SchemaBuilder = struct {
     schema: Schema = .{},
-    allocator: std.mem.Allocator,
 
     /// Creates a new schema builder.
-    pub fn init(allocator: std.mem.Allocator) SchemaBuilder {
-        return .{ .allocator = allocator };
+    pub fn init() SchemaBuilder {
+        return .{};
     }
 
     /// Sets the schema type.
@@ -214,7 +213,6 @@ pub const CommonSchemas = struct {
 
 /// Builder for creating tool input schemas.
 pub const InputSchemaBuilder = struct {
-    allocator: std.mem.Allocator,
     properties: std.StringHashMap(Property),
     required_fields: std.ArrayList([]const u8),
 
@@ -231,104 +229,103 @@ pub const InputSchemaBuilder = struct {
     /// Creates a new input schema builder.
     pub fn init(allocator: std.mem.Allocator) InputSchemaBuilder {
         return .{
-            .allocator = allocator,
             .properties = .init(allocator),
             .required_fields = .empty,
         };
     }
 
     /// Releases resources held by the builder.
-    pub fn deinit(self: *InputSchemaBuilder) void {
+    pub fn deinit(self: *InputSchemaBuilder, allocator: std.mem.Allocator) void {
         self.properties.deinit();
-        self.required_fields.deinit(self.allocator);
+        self.required_fields.deinit(allocator);
     }
 
     /// Adds a string property.
-    pub fn addString(self: *InputSchemaBuilder, name: []const u8, desc: ?[]const u8, required: bool) !*InputSchemaBuilder {
+    pub fn addString(self: *InputSchemaBuilder, allocator: std.mem.Allocator, name: []const u8, desc: ?[]const u8, required: bool) !*InputSchemaBuilder {
         try self.properties.put(name, .{
             .type = "string",
             .description = desc,
         });
         if (required) {
-            try self.required_fields.append(self.allocator, name);
+            try self.required_fields.append(allocator, name);
         }
         return self;
     }
 
     /// Adds a number property.
-    pub fn addNumber(self: *InputSchemaBuilder, name: []const u8, desc: ?[]const u8, required: bool) !*InputSchemaBuilder {
+    pub fn addNumber(self: *InputSchemaBuilder, allocator: std.mem.Allocator, name: []const u8, desc: ?[]const u8, required: bool) !*InputSchemaBuilder {
         try self.properties.put(name, .{
             .type = "number",
             .description = desc,
         });
         if (required) {
-            try self.required_fields.append(self.allocator, name);
+            try self.required_fields.append(allocator, name);
         }
         return self;
     }
 
     /// Adds an integer property.
-    pub fn addInteger(self: *InputSchemaBuilder, name: []const u8, desc: ?[]const u8, required: bool) !*InputSchemaBuilder {
+    pub fn addInteger(self: *InputSchemaBuilder, allocator: std.mem.Allocator, name: []const u8, desc: ?[]const u8, required: bool) !*InputSchemaBuilder {
         try self.properties.put(name, .{
             .type = "integer",
             .description = desc,
         });
         if (required) {
-            try self.required_fields.append(self.allocator, name);
+            try self.required_fields.append(allocator, name);
         }
         return self;
     }
 
     /// Adds a boolean property.
-    pub fn addBoolean(self: *InputSchemaBuilder, name: []const u8, desc: ?[]const u8, required: bool) !*InputSchemaBuilder {
+    pub fn addBoolean(self: *InputSchemaBuilder, allocator: std.mem.Allocator, name: []const u8, desc: ?[]const u8, required: bool) !*InputSchemaBuilder {
         try self.properties.put(name, .{
             .type = "boolean",
             .description = desc,
         });
         if (required) {
-            try self.required_fields.append(self.allocator, name);
+            try self.required_fields.append(allocator, name);
         }
         return self;
     }
 
     /// Adds an enum property.
-    pub fn addEnum(self: *InputSchemaBuilder, name: []const u8, desc: ?[]const u8, values: []const []const u8, required: bool) !*InputSchemaBuilder {
+    pub fn addEnum(self: *InputSchemaBuilder, allocator: std.mem.Allocator, name: []const u8, desc: ?[]const u8, values: []const []const u8, required: bool) !*InputSchemaBuilder {
         try self.properties.put(name, .{
             .type = "string",
             .description = desc,
             .@"enum" = values,
         });
         if (required) {
-            try self.required_fields.append(self.allocator, name);
+            try self.required_fields.append(allocator, name);
         }
         return self;
     }
 
     /// Builds the final input schema as a JSON value.
-    pub fn build(self: *InputSchemaBuilder) !std.json.Value {
+    pub fn build(self: *InputSchemaBuilder, allocator: std.mem.Allocator) !std.json.Value {
         var obj: std.json.ObjectMap = .empty;
-        errdefer obj.deinit(self.allocator);
+        errdefer obj.deinit(allocator);
 
-        try obj.put(self.allocator, "type", .{ .string = "object" });
+        try obj.put(allocator, "type", .{ .string = "object" });
 
         var props: std.json.ObjectMap = .empty;
         var iter = self.properties.iterator();
         while (iter.next()) |entry| {
             var prop_obj: std.json.ObjectMap = .empty;
-            try prop_obj.put(self.allocator, "type", .{ .string = entry.value_ptr.type });
+            try prop_obj.put(allocator, "type", .{ .string = entry.value_ptr.type });
             if (entry.value_ptr.description) |desc| {
-                try prop_obj.put(self.allocator, "description", .{ .string = desc });
+                try prop_obj.put(allocator, "description", .{ .string = desc });
             }
-            try props.put(self.allocator, entry.key_ptr.*, .{ .object = prop_obj });
+            try props.put(allocator, entry.key_ptr.*, .{ .object = prop_obj });
         }
-        try obj.put(self.allocator, "properties", .{ .object = props });
+        try obj.put(allocator, "properties", .{ .object = props });
 
         if (self.required_fields.items.len > 0) {
-            var req: std.json.Array = .init(self.allocator);
+            var req: std.json.Array = .init(allocator);
             for (self.required_fields.items) |name| {
                 try req.append(.{ .string = name });
             }
-            try obj.put(self.allocator, "required", .{ .array = req });
+            try obj.put(allocator, "required", .{ .array = req });
         }
 
         return .{ .object = obj };
@@ -336,8 +333,7 @@ pub const InputSchemaBuilder = struct {
 };
 
 test "SchemaBuilder" {
-    const allocator = std.testing.allocator;
-    var builder: SchemaBuilder = .init(allocator);
+    var builder: SchemaBuilder = .init();
 
     const schema = builder
         .string_()
@@ -354,12 +350,12 @@ test "InputSchemaBuilder" {
     const allocator = arena.allocator();
 
     var builder: InputSchemaBuilder = .init(allocator);
-    defer builder.deinit();
+    defer builder.deinit(allocator);
 
-    _ = try builder.addString("name", "User name", true);
-    _ = try builder.addInteger("age", "User age", false);
+    _ = try builder.addString(allocator, "name", "User name", true);
+    _ = try builder.addInteger(allocator, "age", "User age", false);
 
-    const schema = try builder.build();
+    const schema = try builder.build(allocator);
 
     try std.testing.expectEqualStrings("object", schema.object.get("type").?.string);
 }

--- a/src/protocol/schema.zig
+++ b/src/protocol/schema.zig
@@ -233,7 +233,7 @@ pub const InputSchemaBuilder = struct {
         return .{
             .allocator = allocator,
             .properties = std.StringHashMap(Property).init(allocator),
-            .required_fields = .{},
+            .required_fields = .empty,
         };
     }
 

--- a/src/protocol/schema.zig
+++ b/src/protocol/schema.zig
@@ -48,23 +48,23 @@ pub const Schema = struct {
 
     /// Converts this schema to a JSON value for serialization.
     pub fn toJson(self: Schema, allocator: std.mem.Allocator) !std.json.Value {
-        var obj = std.json.ObjectMap.init(allocator);
-        errdefer obj.deinit();
+        var obj: std.json.ObjectMap = .empty;
+        errdefer obj.deinit(allocator);
 
         if (self.type) |t| {
-            try obj.put("type", .{ .string = t.toString() });
+            try obj.put(allocator, "type", .{ .string = t.toString() });
         }
 
         if (self.description) |desc| {
-            try obj.put("description", .{ .string = desc });
+            try obj.put(allocator, "description", .{ .string = desc });
         }
 
         if (self.title) |t| {
-            try obj.put("title", .{ .string = t });
+            try obj.put(allocator, "title", .{ .string = t });
         }
 
         if (self.properties) |props| {
-            try obj.put("properties", .{ .object = props });
+            try obj.put(allocator, "properties", .{ .object = props });
         }
 
         if (self.required) |req| {
@@ -72,7 +72,7 @@ pub const Schema = struct {
             for (req) |name| {
                 try arr.append(.{ .string = name });
             }
-            try obj.put("required", .{ .array = arr });
+            try obj.put(allocator, "required", .{ .array = arr });
         }
 
         return .{ .object = obj };
@@ -306,29 +306,29 @@ pub const InputSchemaBuilder = struct {
 
     /// Builds the final input schema as a JSON value.
     pub fn build(self: *InputSchemaBuilder) !std.json.Value {
-        var obj = std.json.ObjectMap.init(self.allocator);
-        errdefer obj.deinit();
+        var obj: std.json.ObjectMap = .empty;
+        errdefer obj.deinit(self.allocator);
 
-        try obj.put("type", .{ .string = "object" });
+        try obj.put(self.allocator, "type", .{ .string = "object" });
 
-        var props = std.json.ObjectMap.init(self.allocator);
+        var props: std.json.ObjectMap = .empty;
         var iter = self.properties.iterator();
         while (iter.next()) |entry| {
-            var prop_obj = std.json.ObjectMap.init(self.allocator);
-            try prop_obj.put("type", .{ .string = entry.value_ptr.type });
+            var prop_obj: std.json.ObjectMap = .empty;
+            try prop_obj.put(self.allocator, "type", .{ .string = entry.value_ptr.type });
             if (entry.value_ptr.description) |desc| {
-                try prop_obj.put("description", .{ .string = desc });
+                try prop_obj.put(self.allocator, "description", .{ .string = desc });
             }
-            try props.put(entry.key_ptr.*, .{ .object = prop_obj });
+            try props.put(self.allocator, entry.key_ptr.*, .{ .object = prop_obj });
         }
-        try obj.put("properties", .{ .object = props });
+        try obj.put(self.allocator, "properties", .{ .object = props });
 
         if (self.required_fields.items.len > 0) {
             var req = std.json.Array.init(self.allocator);
             for (self.required_fields.items) |name| {
                 try req.append(.{ .string = name });
             }
-            try obj.put("required", .{ .array = req });
+            try obj.put(self.allocator, "required", .{ .array = req });
         }
 
         return .{ .object = obj };

--- a/src/protocol/schema.zig
+++ b/src/protocol/schema.zig
@@ -68,7 +68,7 @@ pub const Schema = struct {
         }
 
         if (self.required) |req| {
-            var arr = std.json.Array.init(allocator);
+            var arr: std.json.Array = .init(allocator);
             for (req) |name| {
                 try arr.append(.{ .string = name });
             }
@@ -232,7 +232,7 @@ pub const InputSchemaBuilder = struct {
     pub fn init(allocator: std.mem.Allocator) InputSchemaBuilder {
         return .{
             .allocator = allocator,
-            .properties = std.StringHashMap(Property).init(allocator),
+            .properties = .init(allocator),
             .required_fields = .empty,
         };
     }
@@ -324,7 +324,7 @@ pub const InputSchemaBuilder = struct {
         try obj.put(self.allocator, "properties", .{ .object = props });
 
         if (self.required_fields.items.len > 0) {
-            var req = std.json.Array.init(self.allocator);
+            var req: std.json.Array = .init(self.allocator);
             for (self.required_fields.items) |name| {
                 try req.append(.{ .string = name });
             }
@@ -337,7 +337,7 @@ pub const InputSchemaBuilder = struct {
 
 test "SchemaBuilder" {
     const allocator = std.testing.allocator;
-    var builder = SchemaBuilder.init(allocator);
+    var builder: SchemaBuilder = .init(allocator);
 
     const schema = builder
         .string_()
@@ -349,11 +349,11 @@ test "SchemaBuilder" {
 }
 
 test "InputSchemaBuilder" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    var builder = InputSchemaBuilder.init(allocator);
+    var builder: InputSchemaBuilder = .init(allocator);
     defer builder.deinit();
 
     _ = try builder.addString("name", "User name", true);

--- a/src/protocol/types.zig
+++ b/src/protocol/types.zig
@@ -641,19 +641,19 @@ pub const Result = struct {
 };
 
 test "RequestId equality" {
-    const id1 = RequestId{ .integer = 42 };
-    const id2 = RequestId{ .integer = 42 };
-    const id3 = RequestId{ .string = "abc" };
+    const id1: RequestId = .{ .integer = 42 };
+    const id2: RequestId = .{ .integer = 42 };
+    const id3: RequestId = .{ .string = "abc" };
 
     try std.testing.expect(id1.eql(id2));
     try std.testing.expect(!id1.eql(id3));
 }
 
 test "ContentBlock text access" {
-    const content = ContentBlock{ .text = .{ .text = "Hello" } };
+    const content: ContentBlock = .{ .text = .{ .text = "Hello" } };
     try std.testing.expectEqualStrings("Hello", content.asText().?);
 
-    const image = ContentBlock{ .image = .{ .data = "base64", .mimeType = "image/png" } };
+    const image: ContentBlock = .{ .image = .{ .data = "base64", .mimeType = "image/png" } };
     try std.testing.expect(image.asText() == null);
 }
 
@@ -670,11 +670,11 @@ test "TaskStatus" {
 }
 
 test "ContentBlock audio variant" {
-    const audio = ContentBlock{ .audio = .{ .data = "base64audio", .mimeType = "audio/wav" } };
+    const audio: ContentBlock = .{ .audio = .{ .data = "base64audio", .mimeType = "audio/wav" } };
     try std.testing.expect(audio.asText() == null);
 }
 
 test "ContentBlock resource_link variant" {
-    const link = ContentBlock{ .resource_link = .{ .name = "test", .uri = "file:///test.txt" } };
+    const link: ContentBlock = .{ .resource_link = .{ .name = "test", .uri = "file:///test.txt" } };
     try std.testing.expect(link.asText() == null);
 }

--- a/src/report.zig
+++ b/src/report.zig
@@ -3,17 +3,17 @@
 //! Provides functionality for error reporting and checking for library updates.
 
 const std = @import("std");
-const builtin = @import("builtin");
 const http = std.http;
 const SemanticVersion = std.SemanticVersion;
-const version_info = @import("version.zig");
+const builtin = @import("builtin");
+
 const Network = @import("utils/network.zig");
+const version_info = @import("version.zig");
+const CURRENT_VERSION: []const u8 = version_info.version;
 
 pub const ISSUES_URL = "https://github.com/muhammad-fiaz/mcp.zig/issues";
 const REPO_OWNER = "muhammad-fiaz";
 const REPO_NAME = "mcp.zig";
-const CURRENT_VERSION: []const u8 = version_info.version;
-
 /// Prints an error message with instructions for reporting bugs.
 pub fn reportError(err: anyerror) void {
     std.debug.print("\n[MCP ERROR] {}\n", .{err});
@@ -28,7 +28,7 @@ pub fn reportErrorMessage(message: []const u8) void {
 
 /// Static flag to ensure update check runs only once per process
 var update_check_done = false;
-var update_check_mutex = std.Thread.Mutex{};
+var update_check_mutex: std.Io.Mutex = .init;
 
 fn stripVersionPrefix(tag: []const u8) []const u8 {
     if (tag.len == 0) return tag;
@@ -58,14 +58,14 @@ fn compareVersions(latest_raw: []const u8) VersionRelation {
     return .unknown;
 }
 
-fn fetchLatestTag(allocator: std.mem.Allocator) ![]const u8 {
+fn fetchLatestTag(io: std.Io, allocator: std.mem.Allocator) ![]const u8 {
     const url = std.fmt.comptimePrint("https://api.github.com/repos/{s}/{s}/releases/latest", .{ REPO_OWNER, REPO_NAME });
     const extra_headers = [_]http.Header{
         .{ .name = "Accept", .value = "application/vnd.github+json" },
         .{ .name = "User-Agent", .value = "mcp.zig" },
     };
 
-    const parsed = Network.fetchJson(allocator, url, &extra_headers) catch return error.TagMissing;
+    const parsed = Network.fetchJson(io, allocator, url, &extra_headers) catch return error.TagMissing;
     defer parsed.deinit();
 
     return switch (parsed.value) {
@@ -85,21 +85,21 @@ fn fetchLatestTag(allocator: std.mem.Allocator) ![]const u8 {
 /// Checks for updates in a background thread (runs only once per process).
 /// Returns a thread handle so callers can optionally join during shutdown.
 /// Fails silently on errors (no internet, api limits, etc).
-pub fn checkForUpdates(allocator: std.mem.Allocator) ?std.Thread {
+pub fn checkForUpdates(io: std.Io, allocator: std.mem.Allocator) ?std.Thread {
     if (builtin.is_test) return null;
 
-    update_check_mutex.lock();
-    defer update_check_mutex.unlock();
+    update_check_mutex.lock(io) catch return null;
+    defer update_check_mutex.unlock(io);
 
     // Prevent multiple concurrent update checks
     if (update_check_done) return null;
     update_check_done = true;
 
-    return std.Thread.spawn(.{}, checkWorker, .{allocator}) catch null;
+    return std.Thread.spawn(.{}, checkWorker, .{ io, allocator }) catch null;
 }
 
-fn checkWorker(allocator: std.mem.Allocator) void {
-    const latest_tag = fetchLatestTag(allocator) catch return;
+fn checkWorker(io: std.Io, allocator: std.mem.Allocator) void {
+    const latest_tag = fetchLatestTag(io, allocator) catch return;
     defer allocator.free(latest_tag);
 
     // Use ASCII-safe indicators instead of emoji for cross-platform compatibility

--- a/src/server/prompts.zig
+++ b/src/server/prompts.zig
@@ -129,7 +129,7 @@ pub fn assistantMessage(text: []const u8) PromptMessage {
 
 test "PromptBuilder" {
     const allocator = std.testing.allocator;
-    var builder = PromptBuilder.init(allocator, "test_prompt");
+    var builder: PromptBuilder = .init(allocator, "test_prompt");
     defer builder.deinit();
 
     _ = try builder.addArgument("name", "User name", true);

--- a/src/server/prompts.zig
+++ b/src/server/prompts.zig
@@ -44,22 +44,20 @@ pub const PromptError = error{
 
 /// Builder for creating prompts with a fluent API.
 pub const PromptBuilder = struct {
-    allocator: std.mem.Allocator,
     prompt: Prompt,
     args_list: std.ArrayList(PromptArgument),
 
     /// Creates a new prompt builder with the given name.
-    pub fn init(allocator: std.mem.Allocator, name: []const u8) PromptBuilder {
+    pub fn init(name: []const u8) PromptBuilder {
         return .{
-            .allocator = allocator,
             .prompt = .{ .name = name, .handler = defaultHandler },
             .args_list = .empty,
         };
     }
 
     /// Releases resources held by the builder.
-    pub fn deinit(self: *PromptBuilder) void {
-        self.args_list.deinit(self.allocator);
+    pub fn deinit(self: *PromptBuilder, allocator: std.mem.Allocator) void {
+        self.args_list.deinit(allocator);
     }
 
     /// Sets the prompt description.
@@ -75,14 +73,14 @@ pub const PromptBuilder = struct {
     }
 
     /// Adds an argument specification to the prompt.
-    pub fn addArgument(self: *PromptBuilder, name: []const u8, desc: ?[]const u8, required: bool) !*PromptBuilder {
-        try self.args_list.append(self.allocator, .{ .name = name, .description = desc, .required = required });
+    pub fn addArgument(self: *PromptBuilder, allocator: std.mem.Allocator, name: []const u8, desc: ?[]const u8, required: bool) !*PromptBuilder {
+        try self.args_list.append(allocator, .{ .name = name, .description = desc, .required = required });
         return self;
     }
 
     /// Adds an argument specification with a title to the prompt.
-    pub fn addArgumentWithTitle(self: *PromptBuilder, name: []const u8, arg_title: ?[]const u8, desc: ?[]const u8, required: bool) !*PromptBuilder {
-        try self.args_list.append(self.allocator, .{ .name = name, .title = arg_title, .description = desc, .required = required });
+    pub fn addArgumentWithTitle(self: *PromptBuilder, allocator: std.mem.Allocator, name: []const u8, arg_title: ?[]const u8, desc: ?[]const u8, required: bool) !*PromptBuilder {
+        try self.args_list.append(allocator, .{ .name = name, .title = arg_title, .description = desc, .required = required });
         return self;
     }
 
@@ -129,10 +127,10 @@ pub fn assistantMessage(text: []const u8) PromptMessage {
 
 test "PromptBuilder" {
     const allocator = std.testing.allocator;
-    var builder: PromptBuilder = .init(allocator, "test_prompt");
-    defer builder.deinit();
+    var builder: PromptBuilder = .init("test_prompt");
+    defer builder.deinit(allocator);
 
-    _ = try builder.addArgument("name", "User name", true);
+    _ = try builder.addArgument(allocator, "name", "User name", true);
     const prompt = builder.description("A test prompt").build();
 
     try std.testing.expectEqualStrings("test_prompt", prompt.name);

--- a/src/server/prompts.zig
+++ b/src/server/prompts.zig
@@ -16,7 +16,7 @@ pub const Prompt = struct {
     arguments: ?[]const PromptArgument = null,
     icons: ?[]const types.Icon = null,
     _meta: ?std.json.Value = null,
-    handler: *const fn (allocator: std.mem.Allocator, args: ?std.json.Value) PromptError![]const PromptMessage,
+    handler: *const fn (user_data: ?*anyopaque, io: std.Io, allocator: std.mem.Allocator, args: ?std.json.Value) PromptError![]const PromptMessage,
     user_data: ?*anyopaque = null,
 };
 
@@ -85,7 +85,7 @@ pub const PromptBuilder = struct {
     }
 
     /// Sets the prompt handler function.
-    pub fn handler(self: *PromptBuilder, h: *const fn (std.mem.Allocator, ?std.json.Value) PromptError![]const PromptMessage) *PromptBuilder {
+    pub fn handler(self: *PromptBuilder, h: *const fn (?*anyopaque, std.Io, std.mem.Allocator, ?std.json.Value) PromptError![]const PromptMessage) *PromptBuilder {
         self.prompt.handler = h;
         return self;
     }
@@ -98,7 +98,7 @@ pub const PromptBuilder = struct {
         return self.prompt;
     }
 
-    fn defaultHandler(_: std.mem.Allocator, _: ?std.json.Value) PromptError![]const PromptMessage {
+    fn defaultHandler(_: ?*anyopaque, _: std.Io, _: std.mem.Allocator, _: ?std.json.Value) PromptError![]const PromptMessage {
         return &.{};
     }
 };

--- a/src/server/prompts.zig
+++ b/src/server/prompts.zig
@@ -5,6 +5,7 @@
 //! predefined conversation patterns with optional arguments.
 
 const std = @import("std");
+
 const types = @import("../protocol/types.zig");
 
 /// A prompt template exposed by an MCP server.
@@ -52,7 +53,7 @@ pub const PromptBuilder = struct {
         return .{
             .allocator = allocator,
             .prompt = .{ .name = name, .handler = defaultHandler },
-            .args_list = .{},
+            .args_list = .empty,
         };
     }
 

--- a/src/server/resources.zig
+++ b/src/server/resources.zig
@@ -56,13 +56,11 @@ pub const ResourceError = error{
 
 /// Builder for creating resources with a fluent API.
 pub const ResourceBuilder = struct {
-    allocator: std.mem.Allocator,
     resource: Resource,
 
     /// Creates a new resource builder with the given URI and name.
-    pub fn init(allocator: std.mem.Allocator, uri: []const u8, name: []const u8) ResourceBuilder {
+    pub fn init(uri: []const u8, name: []const u8) ResourceBuilder {
         return .{
-            .allocator = allocator,
             .resource = .{ .uri = uri, .name = name, .handler = defaultHandler },
         };
     }
@@ -142,15 +140,13 @@ pub fn detectMimeType(path: []const u8) []const u8 {
 }
 
 test "ResourceBuilder" {
-    const allocator = std.testing.allocator;
-    var builder: ResourceBuilder = .init(allocator, "file:///test.txt", "Test");
+    var builder: ResourceBuilder = .init("file:///test.txt", "Test");
     const resource = builder.description("A test").mimeType("text/plain").build();
     try std.testing.expectEqualStrings("file:///test.txt", resource.uri);
 }
 
 test "ResourceBuilder with title and annotations" {
-    const allocator = std.testing.allocator;
-    var builder: ResourceBuilder = .init(allocator, "file:///data.json", "Data");
+    var builder: ResourceBuilder = .init("file:///data.json", "Data");
     const resource = builder
         .title("Data File")
         .description("JSON data file")

--- a/src/server/resources.zig
+++ b/src/server/resources.zig
@@ -19,7 +19,7 @@ pub const Resource = struct {
     annotations: ?types.Annotations = null,
     size: ?u64 = null,
     _meta: ?std.json.Value = null,
-    handler: *const fn (allocator: std.mem.Allocator, uri: []const u8) ResourceError!ResourceContent,
+    handler: *const fn (user_data: ?*anyopaque, io: std.Io, allocator: std.mem.Allocator, uri: []const u8) ResourceError!ResourceContent,
     user_data: ?*anyopaque = null,
 };
 
@@ -96,7 +96,7 @@ pub const ResourceBuilder = struct {
     }
 
     /// Sets the resource handler function.
-    pub fn handler(self: *ResourceBuilder, h: *const fn (std.mem.Allocator, []const u8) ResourceError!ResourceContent) *ResourceBuilder {
+    pub fn handler(self: *ResourceBuilder, h: *const fn (?*anyopaque, std.Io, std.mem.Allocator, []const u8) ResourceError!ResourceContent) *ResourceBuilder {
         self.resource.handler = h;
         return self;
     }
@@ -106,7 +106,7 @@ pub const ResourceBuilder = struct {
         return self.resource;
     }
 
-    fn defaultHandler(_: std.mem.Allocator, uri: []const u8) ResourceError!ResourceContent {
+    fn defaultHandler(_: ?*anyopaque, _: std.Io, _: std.mem.Allocator, uri: []const u8) ResourceError!ResourceContent {
         return .{ .uri = uri };
     }
 };

--- a/src/server/resources.zig
+++ b/src/server/resources.zig
@@ -5,6 +5,7 @@
 //! such as files, database records, or API responses.
 
 const std = @import("std");
+
 const types = @import("../protocol/types.zig");
 
 /// A resource exposed by an MCP server.
@@ -142,14 +143,14 @@ pub fn detectMimeType(path: []const u8) []const u8 {
 
 test "ResourceBuilder" {
     const allocator = std.testing.allocator;
-    var builder = ResourceBuilder.init(allocator, "file:///test.txt", "Test");
+    var builder: ResourceBuilder = .init(allocator, "file:///test.txt", "Test");
     const resource = builder.description("A test").mimeType("text/plain").build();
     try std.testing.expectEqualStrings("file:///test.txt", resource.uri);
 }
 
 test "ResourceBuilder with title and annotations" {
     const allocator = std.testing.allocator;
-    var builder = ResourceBuilder.init(allocator, "file:///data.json", "Data");
+    var builder: ResourceBuilder = .init(allocator, "file:///data.json", "Data");
     const resource = builder
         .title("Data File")
         .description("JSON data file")

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -496,10 +496,27 @@ pub const Server = struct {
             }
         }
 
+        // use client's requested version if supported
+        var negotiated_version: []const u8 = protocol.VERSION;
+        if (request.params) |params| {
+            if (params == .object) {
+                if (params.object.get("protocolVersion")) |pv| {
+                    if (pv == .string) {
+                        for (protocol.SUPPORTED_VERSIONS) |sv| {
+                            if (std.mem.eql(u8, pv.string, sv)) {
+                                negotiated_version = sv;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         var result: std.json.ObjectMap = .empty;
         defer result.deinit(allocator);
 
-        try result.put(allocator, "protocolVersion", .{ .string = protocol.VERSION });
+        try result.put(allocator, "protocolVersion", .{ .string = negotiated_version });
 
         var caps: std.json.ObjectMap = .empty;
         if (self.capabilities.tools) |t| {

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -16,34 +16,29 @@ const resources_mod = @import("resources.zig");
 const tools_mod = @import("tools.zig");
 
 const HttpRequestTransport = struct {
-    allocator: std.mem.Allocator,
     response_message: ?[]const u8 = null,
     is_closed: bool = false,
 
     const Self = @This();
 
-    pub fn init(allocator: std.mem.Allocator) Self {
-        return .{ .allocator = allocator };
-    }
-
-    pub fn deinit(self: *Self) void {
+    pub fn deinit(self: *Self, allocator: std.mem.Allocator) void {
         if (self.response_message) |msg| {
-            self.allocator.free(msg);
+            allocator.free(msg);
             self.response_message = null;
         }
     }
 
-    pub fn send(self: *Self, message: []const u8) transport_mod.Transport.SendError!void {
+    pub fn send(self: *Self, _: std.Io, allocator: std.mem.Allocator, message: []const u8) transport_mod.Transport.SendError!void {
         if (self.is_closed) return transport_mod.Transport.SendError.ConnectionClosed;
 
-        const owned = self.allocator.dupe(u8, message) catch return transport_mod.Transport.SendError.OutOfMemory;
+        const owned = allocator.dupe(u8, message) catch return transport_mod.Transport.SendError.OutOfMemory;
         if (self.response_message) |old| {
-            self.allocator.free(old);
+            allocator.free(old);
         }
         self.response_message = owned;
     }
 
-    pub fn receive(self: *Self) transport_mod.Transport.ReceiveError!?[]const u8 {
+    pub fn receive(self: *Self, _: std.Io, _: std.mem.Allocator) transport_mod.Transport.ReceiveError!?[]const u8 {
         if (self.is_closed) return transport_mod.Transport.ReceiveError.ConnectionClosed;
         return null;
     }
@@ -63,14 +58,14 @@ const HttpRequestTransport = struct {
         };
     }
 
-    fn sendVtable(ptr: *anyopaque, message: []const u8) transport_mod.Transport.SendError!void {
+    fn sendVtable(ptr: *anyopaque, io: std.Io, allocator: std.mem.Allocator, message: []const u8) transport_mod.Transport.SendError!void {
         const self: *Self = @ptrCast(@alignCast(ptr));
-        return self.send(message);
+        return self.send(io, allocator, message);
     }
 
-    fn receiveVtable(ptr: *anyopaque) transport_mod.Transport.ReceiveError!?[]const u8 {
+    fn receiveVtable(ptr: *anyopaque, io: std.Io, allocator: std.mem.Allocator) transport_mod.Transport.ReceiveError!?[]const u8 {
         const self: *Self = @ptrCast(@alignCast(ptr));
-        return self.receive();
+        return self.receive(io, allocator);
     }
 
     fn closeVtable(ptr: *anyopaque) void {
@@ -88,8 +83,6 @@ pub const ServerConfig = struct {
     icons: ?[]const types.Icon = null,
     websiteUrl: ?[]const u8 = null,
     instructions: ?[]const u8 = null,
-    allocator: std.mem.Allocator = std.heap.page_allocator,
-    io: ?std.Io = null,
 };
 
 /// Current state of the server
@@ -104,8 +97,6 @@ pub const ServerState = enum {
 /// MCP Server that handles client connections and routes requests
 pub const Server = struct {
     config: ServerConfig,
-    allocator: std.mem.Allocator,
-    io: std.Io,
     state: ServerState = .uninitialized,
     tools: std.StringHashMap(tools_mod.Tool),
     resources: std.StringHashMap(resources_mod.Resource),
@@ -129,17 +120,9 @@ pub const Server = struct {
     };
 
     /// Initialize a new MCP Server
-    pub fn init(config: ServerConfig) Self {
-        const allocator = config.allocator;
-        const io = config.io orelse io: {
-            var threaded: std.Io.Threaded = .init_single_threaded;
-            break :io threaded.io();
-        };
-
+    pub fn init(allocator: std.mem.Allocator, config: ServerConfig) Self {
         return .{
             .config = config,
-            .allocator = allocator,
-            .io = io,
             .tools = .init(allocator),
             .resources = .init(allocator),
             .resource_templates = .init(allocator),
@@ -155,11 +138,6 @@ pub const Server = struct {
         self.resource_templates.deinit();
         self.prompts.deinit();
         self.pending_requests.deinit();
-
-        if (self.stdio_transport) |t| {
-            t.deinit();
-            self.allocator.destroy(t);
-        }
     }
 
     /// Add a tool to the server
@@ -223,24 +201,23 @@ pub const Server = struct {
     };
 
     /// Run the server with the specified transport
-    pub fn run(self: *Self, options: RunOptions) !void {
+    pub fn run(self: *Self, io: std.Io, allocator: std.mem.Allocator, options: RunOptions) !void {
         switch (options) {
             .stdio => {
-                self.log("Server listening on STDIO");
-                const stdio = try self.allocator.create(transport_mod.StdioTransport);
-                stdio.* = .init(self.io, self.allocator);
+                self.log(io, "Server listening on STDIO");
+                const stdio = try allocator.create(transport_mod.StdioTransport);
+                stdio.* = .{};
                 self.stdio_transport = stdio;
                 self.transport = stdio.transport();
-                try self.messageLoop();
+                try self.messageLoop(io, allocator);
             },
             .http => |config| {
-                try self.runHttp(config);
+                try self.runHttp(io, allocator, config);
             },
         }
     }
 
-    fn runHttp(self: *Self, config: HttpRunConfig) !void {
-        const io = self.io;
+    fn runHttp(self: *Self, io: std.Io, allocator: std.mem.Allocator, config: HttpRunConfig) !void {
         const bind_host = if (std.mem.eql(u8, config.host, "localhost")) "127.0.0.1" else config.host;
 
         const address = std.Io.net.IpAddress.resolve(io, bind_host, config.port) catch {
@@ -256,13 +233,13 @@ pub const Server = struct {
                 continue;
             };
 
-            self.serveHttpConnection(io, stream) catch |err| {
+            self.serveHttpConnection(io, allocator, stream) catch |err| {
                 std.log.err("HTTP connection error: {s}", .{@errorName(err)});
             };
         }
     }
 
-    fn serveHttpConnection(self: *Self, io: std.Io, stream: std.Io.net.Stream) !void {
+    fn serveHttpConnection(self: *Self, io: std.Io, allocator: std.mem.Allocator, stream: std.Io.net.Stream) !void {
         defer stream.close(io);
 
         var send_buffer: [4096]u8 = undefined;
@@ -286,10 +263,10 @@ pub const Server = struct {
             return;
         }
 
-        try self.handleHttpJsonRpcRequest(&request);
+        try self.handleHttpJsonRpcRequest(io, allocator, &request);
     }
 
-    fn handleHttpJsonRpcRequest(self: *Self, request: *http.Server.Request) !void {
+    fn handleHttpJsonRpcRequest(self: *Self, io: std.Io, allocator: std.mem.Allocator, request: *http.Server.Request) !void {
         const content_length = request.head.content_length orelse {
             try request.respond("Content-Length required", .{
                 .status = .bad_request,
@@ -341,7 +318,7 @@ pub const Server = struct {
             return;
         };
 
-        const body_items = body_reader.readAlloc(self.allocator, read_len) catch {
+        const body_items = body_reader.readAlloc(allocator, read_len) catch {
             try request.respond("Failed to read request body", .{
                 .status = .bad_request,
                 .extra_headers = &.{
@@ -350,18 +327,18 @@ pub const Server = struct {
             });
             return;
         };
-        defer self.allocator.free(body_items);
+        defer allocator.free(body_items);
 
-        var request_transport: HttpRequestTransport = .init(self.allocator);
-        defer request_transport.deinit();
+        var request_transport: HttpRequestTransport = .{};
+        defer request_transport.deinit(allocator);
 
         const previous_transport = self.transport;
         self.transport = request_transport.transport();
         defer self.transport = previous_transport;
 
-        self.handleMessage(body_items) catch {
+        self.handleMessage(io, allocator, body_items) catch {
             const internal_error = jsonrpc.createParseError(.{ .string = "Internal server error" });
-            const json = jsonrpc.serializeMessage(self.allocator, .{ .error_response = internal_error }) catch {
+            const json = jsonrpc.serializeMessage(allocator, .{ .error_response = internal_error }) catch {
                 try request.respond("Internal server error", .{
                     .status = .internal_server_error,
                     .extra_headers = &.{
@@ -370,7 +347,7 @@ pub const Server = struct {
                 });
                 return;
             };
-            defer self.allocator.free(json);
+            defer allocator.free(json);
 
             try request.respond(json, .{
                 .status = .internal_server_error,
@@ -395,29 +372,29 @@ pub const Server = struct {
     }
 
     /// Run the server with a custom transport
-    pub fn runWithTransport(self: *Self, t: transport_mod.Transport) !void {
+    pub fn runWithTransport(self: *Self, io: std.Io, allocator: std.mem.Allocator, t: transport_mod.Transport) !void {
         self.transport = t;
-        try self.messageLoop();
+        try self.messageLoop(io, allocator);
     }
 
     /// Main message processing loop
-    fn messageLoop(self: *Self) !void {
+    fn messageLoop(self: *Self, io: std.Io, allocator: std.mem.Allocator) !void {
         while (self.state != .stopped and self.state != .shutting_down) {
-            const message_data = self.transport.?.receive() catch |err| {
+            const message_data = self.transport.?.receive(io, allocator) catch |err| {
                 switch (err) {
                     error.EndOfStream => {
                         self.state = .shutting_down;
                         break;
                     },
                     else => {
-                        self.logError("Transport receive error");
+                        self.logError(io, "Transport receive error");
                         continue;
                     },
                 }
             };
 
             if (message_data) |data| {
-                try self.handleMessage(data);
+                try self.handleMessage(io, allocator, data);
             }
         }
 
@@ -425,27 +402,27 @@ pub const Server = struct {
     }
 
     /// Handle an incoming message
-    fn handleMessage(self: *Self, data: []const u8) !void {
-        const parsed_message = jsonrpc.parseMessage(self.allocator, data) catch {
+    fn handleMessage(self: *Self, io: std.Io, allocator: std.mem.Allocator, data: []const u8) !void {
+        const parsed_message = jsonrpc.parseMessage(allocator, data) catch {
             const error_response = jsonrpc.createParseError(null);
-            try self.sendResponse(.{ .error_response = error_response });
+            try self.sendResponse(io, allocator, .{ .error_response = error_response });
             return;
         };
         defer parsed_message.deinit();
 
         switch (parsed_message.message) {
-            .request => |req| try self.handleRequest(req),
-            .notification => |notif| try self.handleNotification(notif),
+            .request => |req| try self.handleRequest(io, allocator, req),
+            .notification => |notif| try self.handleNotification(io, notif),
             .response => |resp| self.handleResponse(resp),
-            .error_response => |err| self.handleErrorResponse(err),
+            .error_response => |err| self.handleErrorResponse(io, err),
         }
     }
 
     /// Handle an incoming request
-    fn handleRequest(self: *Self, request: jsonrpc.Request) !void {
+    fn handleRequest(self: *Self, io: std.Io, allocator: std.mem.Allocator, request: jsonrpc.Request) !void {
         var buf: [256]u8 = undefined;
         if (std.fmt.bufPrint(&buf, "Received request: {s}", .{request.method})) |msg| {
-            self.log(msg);
+            self.log(io, msg);
         } else |_| {}
 
         if (self.state == .uninitialized and !std.mem.eql(u8, request.method, "initialize")) {
@@ -455,52 +432,52 @@ pub const Server = struct {
                 "Server not initialized",
                 null,
             );
-            try self.sendResponse(.{ .error_response = error_response });
+            try self.sendResponse(io, allocator, .{ .error_response = error_response });
             return;
         }
 
         if (std.mem.eql(u8, request.method, "initialize")) {
-            try self.handleInitialize(request);
+            try self.handleInitialize(io, allocator, request);
         } else if (std.mem.eql(u8, request.method, "ping")) {
-            try self.handlePing(request);
+            try self.handlePing(io, allocator, request);
         } else if (std.mem.eql(u8, request.method, "tools/list")) {
-            try self.handleToolsList(request);
+            try self.handleToolsList(io, allocator, request);
         } else if (std.mem.eql(u8, request.method, "tools/call")) {
-            try self.handleToolsCall(request);
+            try self.handleToolsCall(io, allocator, request);
         } else if (std.mem.eql(u8, request.method, "resources/list")) {
-            try self.handleResourcesList(request);
+            try self.handleResourcesList(io, allocator, request);
         } else if (std.mem.eql(u8, request.method, "resources/read")) {
-            try self.handleResourcesRead(request);
+            try self.handleResourcesRead(io, allocator, request);
         } else if (std.mem.eql(u8, request.method, "resources/templates/list")) {
-            try self.handleResourceTemplatesList(request);
+            try self.handleResourceTemplatesList(io, allocator, request);
         } else if (std.mem.eql(u8, request.method, "resources/subscribe")) {
-            try self.handleSubscribe(request);
+            try self.handleSubscribe(io, allocator, request);
         } else if (std.mem.eql(u8, request.method, "resources/unsubscribe")) {
-            try self.handleUnsubscribe(request);
+            try self.handleUnsubscribe(io, allocator, request);
         } else if (std.mem.eql(u8, request.method, "prompts/list")) {
-            try self.handlePromptsList(request);
+            try self.handlePromptsList(io, allocator, request);
         } else if (std.mem.eql(u8, request.method, "prompts/get")) {
-            try self.handlePromptsGet(request);
+            try self.handlePromptsGet(io, allocator, request);
         } else if (std.mem.eql(u8, request.method, "logging/setLevel")) {
-            try self.handleSetLogLevel(request);
+            try self.handleSetLogLevel(io, allocator, request);
         } else if (std.mem.eql(u8, request.method, "completion/complete")) {
-            try self.handleCompletion(request);
+            try self.handleCompletion(io, allocator, request);
         } else if (std.mem.eql(u8, request.method, "tasks/get")) {
-            try self.handleTasksGet(request);
+            try self.handleTasksGet(io, allocator, request);
         } else if (std.mem.eql(u8, request.method, "tasks/result")) {
-            try self.handleTasksResult(request);
+            try self.handleTasksResult(io, allocator, request);
         } else if (std.mem.eql(u8, request.method, "tasks/list")) {
-            try self.handleTasksList(request);
+            try self.handleTasksList(io, allocator, request);
         } else if (std.mem.eql(u8, request.method, "tasks/cancel")) {
-            try self.handleTasksCancel(request);
+            try self.handleTasksCancel(io, allocator, request);
         } else {
             const error_response = jsonrpc.createMethodNotFound(request.id, request.method);
-            try self.sendResponse(.{ .error_response = error_response });
+            try self.sendResponse(io, allocator, .{ .error_response = error_response });
         }
     }
 
     /// Handle initialize request
-    fn handleInitialize(self: *Self, request: jsonrpc.Request) !void {
+    fn handleInitialize(self: *Self, io: std.Io, allocator: std.mem.Allocator, request: jsonrpc.Request) !void {
         self.state = .initializing;
 
         if (request.params) |params| {
@@ -520,126 +497,126 @@ pub const Server = struct {
         }
 
         var result: std.json.ObjectMap = .empty;
-        defer result.deinit(self.allocator);
+        defer result.deinit(allocator);
 
-        try result.put(self.allocator, "protocolVersion", .{ .string = protocol.VERSION });
+        try result.put(allocator, "protocolVersion", .{ .string = protocol.VERSION });
 
         var caps: std.json.ObjectMap = .empty;
         if (self.capabilities.tools) |t| {
             var tools_cap: std.json.ObjectMap = .empty;
-            try tools_cap.put(self.allocator, "listChanged", .{ .bool = t.listChanged });
-            try caps.put(self.allocator, "tools", .{ .object = tools_cap });
+            try tools_cap.put(allocator, "listChanged", .{ .bool = t.listChanged });
+            try caps.put(allocator, "tools", .{ .object = tools_cap });
         }
         if (self.capabilities.resources) |r| {
             var res_cap: std.json.ObjectMap = .empty;
-            try res_cap.put(self.allocator, "listChanged", .{ .bool = r.listChanged });
-            try res_cap.put(self.allocator, "subscribe", .{ .bool = r.subscribe });
-            try caps.put(self.allocator, "resources", .{ .object = res_cap });
+            try res_cap.put(allocator, "listChanged", .{ .bool = r.listChanged });
+            try res_cap.put(allocator, "subscribe", .{ .bool = r.subscribe });
+            try caps.put(allocator, "resources", .{ .object = res_cap });
         }
         if (self.capabilities.prompts) |p| {
             var prompts_cap: std.json.ObjectMap = .empty;
-            try prompts_cap.put(self.allocator, "listChanged", .{ .bool = p.listChanged });
-            try caps.put(self.allocator, "prompts", .{ .object = prompts_cap });
+            try prompts_cap.put(allocator, "listChanged", .{ .bool = p.listChanged });
+            try caps.put(allocator, "prompts", .{ .object = prompts_cap });
         }
         if (self.capabilities.logging != null) {
-            try caps.put(self.allocator, "logging", .{ .object = .empty });
+            try caps.put(allocator, "logging", .{ .object = .empty });
         }
         if (self.capabilities.completions != null) {
-            try caps.put(self.allocator, "completions", .{ .object = .empty });
+            try caps.put(allocator, "completions", .{ .object = .empty });
         }
         if (self.capabilities.tasks != null) {
             var tasks_cap: std.json.ObjectMap = .empty;
-            try tasks_cap.put(self.allocator, "list", .{ .object = .empty });
-            try tasks_cap.put(self.allocator, "cancel", .{ .object = .empty });
+            try tasks_cap.put(allocator, "list", .{ .object = .empty });
+            try tasks_cap.put(allocator, "cancel", .{ .object = .empty });
             var requests_cap: std.json.ObjectMap = .empty;
             var tools_req: std.json.ObjectMap = .empty;
-            try tools_req.put(self.allocator, "call", .{ .object = .empty });
-            try requests_cap.put(self.allocator, "tools", .{ .object = tools_req });
-            try tasks_cap.put(self.allocator, "requests", .{ .object = requests_cap });
-            try caps.put(self.allocator, "tasks", .{ .object = tasks_cap });
+            try tools_req.put(allocator, "call", .{ .object = .empty });
+            try requests_cap.put(allocator, "tools", .{ .object = tools_req });
+            try tasks_cap.put(allocator, "requests", .{ .object = requests_cap });
+            try caps.put(allocator, "tasks", .{ .object = tasks_cap });
         }
-        try result.put(self.allocator, "capabilities", .{ .object = caps });
+        try result.put(allocator, "capabilities", .{ .object = caps });
 
         var server_info: std.json.ObjectMap = .empty;
-        try server_info.put(self.allocator, "name", .{ .string = self.config.name });
-        try server_info.put(self.allocator, "version", .{ .string = self.config.version });
+        try server_info.put(allocator, "name", .{ .string = self.config.name });
+        try server_info.put(allocator, "version", .{ .string = self.config.version });
         if (self.config.title) |t| {
-            try server_info.put(self.allocator, "title", .{ .string = t });
+            try server_info.put(allocator, "title", .{ .string = t });
         }
         if (self.config.description) |d| {
-            try server_info.put(self.allocator, "description", .{ .string = d });
+            try server_info.put(allocator, "description", .{ .string = d });
         }
         if (self.config.websiteUrl) |u| {
-            try server_info.put(self.allocator, "websiteUrl", .{ .string = u });
+            try server_info.put(allocator, "websiteUrl", .{ .string = u });
         }
-        try result.put(self.allocator, "serverInfo", .{ .object = server_info });
+        try result.put(allocator, "serverInfo", .{ .object = server_info });
 
         if (self.config.instructions) |inst| {
-            try result.put(self.allocator, "instructions", .{ .string = inst });
+            try result.put(allocator, "instructions", .{ .string = inst });
         }
 
         const response = jsonrpc.createResponse(request.id, .{ .object = result });
-        try self.sendResponse(.{ .response = response });
+        try self.sendResponse(io, allocator, .{ .response = response });
     }
 
     /// Handle ping request
-    fn handlePing(self: *Self, request: jsonrpc.Request) !void {
+    fn handlePing(self: *Self, io: std.Io, allocator: std.mem.Allocator, request: jsonrpc.Request) !void {
         var result: std.json.ObjectMap = .empty;
-        defer result.deinit(self.allocator);
+        defer result.deinit(allocator);
 
         const response = jsonrpc.createResponse(request.id, .{ .object = result });
-        try self.sendResponse(.{ .response = response });
+        try self.sendResponse(io, allocator, .{ .response = response });
     }
 
     /// Handle tools/list request
-    fn handleToolsList(self: *Self, request: jsonrpc.Request) !void {
-        var tools_array: std.json.Array = .init(self.allocator);
+    fn handleToolsList(self: *Self, io: std.Io, allocator: std.mem.Allocator, request: jsonrpc.Request) !void {
+        var tools_array: std.json.Array = .init(allocator);
 
         var iter = self.tools.iterator();
         while (iter.next()) |entry| {
             var tool_obj: std.json.ObjectMap = .empty;
-            try tool_obj.put(self.allocator, "name", .{ .string = entry.value_ptr.name });
+            try tool_obj.put(allocator, "name", .{ .string = entry.value_ptr.name });
             if (entry.value_ptr.description) |desc| {
-                try tool_obj.put(self.allocator, "description", .{ .string = desc });
+                try tool_obj.put(allocator, "description", .{ .string = desc });
             }
             if (entry.value_ptr.title) |t| {
-                try tool_obj.put(self.allocator, "title", .{ .string = t });
+                try tool_obj.put(allocator, "title", .{ .string = t });
             }
 
             var input_schema: std.json.ObjectMap = .empty;
-            try input_schema.put(self.allocator, "type", .{ .string = "object" });
-            try tool_obj.put(self.allocator, "inputSchema", .{ .object = input_schema });
+            try input_schema.put(allocator, "type", .{ .string = "object" });
+            try tool_obj.put(allocator, "inputSchema", .{ .object = input_schema });
 
             if (entry.value_ptr.annotations) |ann| {
                 var ann_obj: std.json.ObjectMap = .empty;
-                if (ann.title) |t| try ann_obj.put(self.allocator, "title", .{ .string = t });
-                try ann_obj.put(self.allocator, "readOnlyHint", .{ .bool = ann.readOnlyHint });
-                try ann_obj.put(self.allocator, "destructiveHint", .{ .bool = ann.destructiveHint });
-                try ann_obj.put(self.allocator, "idempotentHint", .{ .bool = ann.idempotentHint });
-                try ann_obj.put(self.allocator, "openWorldHint", .{ .bool = ann.openWorldHint });
-                try tool_obj.put(self.allocator, "annotations", .{ .object = ann_obj });
+                if (ann.title) |t| try ann_obj.put(allocator, "title", .{ .string = t });
+                try ann_obj.put(allocator, "readOnlyHint", .{ .bool = ann.readOnlyHint });
+                try ann_obj.put(allocator, "destructiveHint", .{ .bool = ann.destructiveHint });
+                try ann_obj.put(allocator, "idempotentHint", .{ .bool = ann.idempotentHint });
+                try ann_obj.put(allocator, "openWorldHint", .{ .bool = ann.openWorldHint });
+                try tool_obj.put(allocator, "annotations", .{ .object = ann_obj });
             }
 
             if (entry.value_ptr.execution) |exec| {
                 var exec_obj: std.json.ObjectMap = .empty;
                 if (exec.taskSupport) |ts| {
-                    try exec_obj.put(self.allocator, "taskSupport", .{ .string = ts });
+                    try exec_obj.put(allocator, "taskSupport", .{ .string = ts });
                 }
-                try tool_obj.put(self.allocator, "execution", .{ .object = exec_obj });
+                try tool_obj.put(allocator, "execution", .{ .object = exec_obj });
             }
 
             try tools_array.append(.{ .object = tool_obj });
         }
 
         var result: std.json.ObjectMap = .empty;
-        try result.put(self.allocator, "tools", .{ .array = tools_array });
+        try result.put(allocator, "tools", .{ .array = tools_array });
 
         const response = jsonrpc.createResponse(request.id, .{ .object = result });
-        try self.sendResponse(.{ .response = response });
+        try self.sendResponse(io, allocator, .{ .response = response });
     }
 
     /// Handle tools/call request
-    fn handleToolsCall(self: *Self, request: jsonrpc.Request) !void {
+    fn handleToolsCall(self: *Self, io: std.Io, allocator: std.mem.Allocator, request: jsonrpc.Request) !void {
         var tool_name: []const u8 = "";
         var arguments: ?std.json.Value = null;
 
@@ -655,108 +632,108 @@ pub const Server = struct {
         }
 
         if (self.tools.get(tool_name)) |tool| {
-            const tool_result = tool.handler(self.allocator, arguments) catch |err| {
-                var content_array: std.json.Array = .init(self.allocator);
+            const tool_result = tool.handler(allocator, arguments) catch |err| {
+                var content_array: std.json.Array = .init(allocator);
                 var text_obj: std.json.ObjectMap = .empty;
-                try text_obj.put(self.allocator, "type", .{ .string = "text" });
-                try text_obj.put(self.allocator, "text", .{ .string = @errorName(err) });
+                try text_obj.put(allocator, "type", .{ .string = "text" });
+                try text_obj.put(allocator, "text", .{ .string = @errorName(err) });
                 try content_array.append(.{ .object = text_obj });
 
                 var result: std.json.ObjectMap = .empty;
-                try result.put(self.allocator, "content", .{ .array = content_array });
-                try result.put(self.allocator, "isError", .{ .bool = true });
+                try result.put(allocator, "content", .{ .array = content_array });
+                try result.put(allocator, "isError", .{ .bool = true });
 
                 const response = jsonrpc.createResponse(request.id, .{ .object = result });
-                try self.sendResponse(.{ .response = response });
+                try self.sendResponse(io, allocator, .{ .response = response });
                 return;
             };
 
-            var content_array: std.json.Array = .init(self.allocator);
+            var content_array: std.json.Array = .init(allocator);
             for (tool_result.content) |content_item| {
                 var item_obj: std.json.ObjectMap = .empty;
                 switch (content_item) {
                     .text => |text| {
-                        try item_obj.put(self.allocator, "type", .{ .string = "text" });
-                        try item_obj.put(self.allocator, "text", .{ .string = text.text });
+                        try item_obj.put(allocator, "type", .{ .string = "text" });
+                        try item_obj.put(allocator, "text", .{ .string = text.text });
                     },
                     .image => |img| {
-                        try item_obj.put(self.allocator, "type", .{ .string = "image" });
-                        try item_obj.put(self.allocator, "data", .{ .string = img.data });
-                        try item_obj.put(self.allocator, "mimeType", .{ .string = img.mimeType });
+                        try item_obj.put(allocator, "type", .{ .string = "image" });
+                        try item_obj.put(allocator, "data", .{ .string = img.data });
+                        try item_obj.put(allocator, "mimeType", .{ .string = img.mimeType });
                     },
                     .audio => |aud| {
-                        try item_obj.put(self.allocator, "type", .{ .string = "audio" });
-                        try item_obj.put(self.allocator, "data", .{ .string = aud.data });
-                        try item_obj.put(self.allocator, "mimeType", .{ .string = aud.mimeType });
+                        try item_obj.put(allocator, "type", .{ .string = "audio" });
+                        try item_obj.put(allocator, "data", .{ .string = aud.data });
+                        try item_obj.put(allocator, "mimeType", .{ .string = aud.mimeType });
                     },
                     .resource_link => |link| {
-                        try item_obj.put(self.allocator, "type", .{ .string = "resource_link" });
-                        try item_obj.put(self.allocator, "uri", .{ .string = link.uri });
-                        try item_obj.put(self.allocator, "name", .{ .string = link.name });
-                        if (link.title) |t| try item_obj.put(self.allocator, "title", .{ .string = t });
-                        if (link.description) |d| try item_obj.put(self.allocator, "description", .{ .string = d });
-                        if (link.mimeType) |m| try item_obj.put(self.allocator, "mimeType", .{ .string = m });
+                        try item_obj.put(allocator, "type", .{ .string = "resource_link" });
+                        try item_obj.put(allocator, "uri", .{ .string = link.uri });
+                        try item_obj.put(allocator, "name", .{ .string = link.name });
+                        if (link.title) |t| try item_obj.put(allocator, "title", .{ .string = t });
+                        if (link.description) |d| try item_obj.put(allocator, "description", .{ .string = d });
+                        if (link.mimeType) |m| try item_obj.put(allocator, "mimeType", .{ .string = m });
                     },
                     .resource => |res| {
-                        try item_obj.put(self.allocator, "type", .{ .string = "resource" });
+                        try item_obj.put(allocator, "type", .{ .string = "resource" });
                         var res_obj: std.json.ObjectMap = .empty;
-                        try res_obj.put(self.allocator, "uri", .{ .string = res.resource.uri });
-                        if (res.resource.text) |text| try res_obj.put(self.allocator, "text", .{ .string = text });
-                        if (res.resource.mimeType) |mime| try res_obj.put(self.allocator, "mimeType", .{ .string = mime });
-                        try item_obj.put(self.allocator, "resource", .{ .object = res_obj });
+                        try res_obj.put(allocator, "uri", .{ .string = res.resource.uri });
+                        if (res.resource.text) |text| try res_obj.put(allocator, "text", .{ .string = text });
+                        if (res.resource.mimeType) |mime| try res_obj.put(allocator, "mimeType", .{ .string = mime });
+                        try item_obj.put(allocator, "resource", .{ .object = res_obj });
                     },
                 }
                 try content_array.append(.{ .object = item_obj });
             }
 
             var result: std.json.ObjectMap = .empty;
-            try result.put(self.allocator, "content", .{ .array = content_array });
-            try result.put(self.allocator, "isError", .{ .bool = tool_result.is_error });
+            try result.put(allocator, "content", .{ .array = content_array });
+            try result.put(allocator, "isError", .{ .bool = tool_result.is_error });
             if (tool_result.structuredContent) |sc| {
-                try result.put(self.allocator, "structuredContent", sc);
+                try result.put(allocator, "structuredContent", sc);
             }
 
             const response = jsonrpc.createResponse(request.id, .{ .object = result });
-            try self.sendResponse(.{ .response = response });
+            try self.sendResponse(io, allocator, .{ .response = response });
         } else {
             const error_response = jsonrpc.createInvalidParams(request.id, "Tool not found");
-            try self.sendResponse(.{ .error_response = error_response });
+            try self.sendResponse(io, allocator, .{ .error_response = error_response });
         }
     }
 
     /// Handle resources/list request
-    fn handleResourcesList(self: *Self, request: jsonrpc.Request) !void {
-        var resources_array: std.json.Array = .init(self.allocator);
+    fn handleResourcesList(self: *Self, io: std.Io, allocator: std.mem.Allocator, request: jsonrpc.Request) !void {
+        var resources_array: std.json.Array = .init(allocator);
 
         var iter = self.resources.iterator();
         while (iter.next()) |entry| {
             var resource_obj: std.json.ObjectMap = .empty;
-            try resource_obj.put(self.allocator, "uri", .{ .string = entry.value_ptr.uri });
-            try resource_obj.put(self.allocator, "name", .{ .string = entry.value_ptr.name });
+            try resource_obj.put(allocator, "uri", .{ .string = entry.value_ptr.uri });
+            try resource_obj.put(allocator, "name", .{ .string = entry.value_ptr.name });
             if (entry.value_ptr.title) |t| {
-                try resource_obj.put(self.allocator, "title", .{ .string = t });
+                try resource_obj.put(allocator, "title", .{ .string = t });
             }
             if (entry.value_ptr.description) |desc| {
-                try resource_obj.put(self.allocator, "description", .{ .string = desc });
+                try resource_obj.put(allocator, "description", .{ .string = desc });
             }
             if (entry.value_ptr.mimeType) |mime| {
-                try resource_obj.put(self.allocator, "mimeType", .{ .string = mime });
+                try resource_obj.put(allocator, "mimeType", .{ .string = mime });
             }
             if (entry.value_ptr.size) |s| {
-                try resource_obj.put(self.allocator, "size", .{ .integer = @intCast(s) });
+                try resource_obj.put(allocator, "size", .{ .integer = @intCast(s) });
             }
             try resources_array.append(.{ .object = resource_obj });
         }
 
         var result: std.json.ObjectMap = .empty;
-        try result.put(self.allocator, "resources", .{ .array = resources_array });
+        try result.put(allocator, "resources", .{ .array = resources_array });
 
         const response = jsonrpc.createResponse(request.id, .{ .object = result });
-        try self.sendResponse(.{ .response = response });
+        try self.sendResponse(io, allocator, .{ .response = response });
     }
 
     /// Handle resources/read request
-    fn handleResourcesRead(self: *Self, request: jsonrpc.Request) !void {
+    fn handleResourcesRead(self: *Self, io: std.Io, allocator: std.mem.Allocator, request: jsonrpc.Request) !void {
         var uri: []const u8 = "";
 
         if (request.params) |params| {
@@ -770,127 +747,127 @@ pub const Server = struct {
         }
 
         if (self.resources.get(uri)) |resource| {
-            const content = resource.handler(self.allocator, uri) catch |err| {
+            const content = resource.handler(allocator, uri) catch |err| {
                 const error_response = jsonrpc.createInternalError(request.id, .{ .string = @errorName(err) });
-                try self.sendResponse(.{ .error_response = error_response });
+                try self.sendResponse(io, allocator, .{ .error_response = error_response });
                 return;
             };
 
-            var contents_array: std.json.Array = .init(self.allocator);
+            var contents_array: std.json.Array = .init(allocator);
             var content_obj: std.json.ObjectMap = .empty;
-            try content_obj.put(self.allocator, "uri", .{ .string = uri });
+            try content_obj.put(allocator, "uri", .{ .string = uri });
             if (content.text) |text| {
-                try content_obj.put(self.allocator, "text", .{ .string = text });
+                try content_obj.put(allocator, "text", .{ .string = text });
             }
             if (content.blob) |blob| {
-                try content_obj.put(self.allocator, "blob", .{ .string = blob });
+                try content_obj.put(allocator, "blob", .{ .string = blob });
             }
             if (content.mimeType) |mime| {
-                try content_obj.put(self.allocator, "mimeType", .{ .string = mime });
+                try content_obj.put(allocator, "mimeType", .{ .string = mime });
             }
             try contents_array.append(.{ .object = content_obj });
 
             var result: std.json.ObjectMap = .empty;
-            try result.put(self.allocator, "contents", .{ .array = contents_array });
+            try result.put(allocator, "contents", .{ .array = contents_array });
 
             const response = jsonrpc.createResponse(request.id, .{ .object = result });
-            try self.sendResponse(.{ .response = response });
+            try self.sendResponse(io, allocator, .{ .response = response });
         } else {
             const error_response = jsonrpc.createInvalidParams(request.id, "Resource not found");
-            try self.sendResponse(.{ .error_response = error_response });
+            try self.sendResponse(io, allocator, .{ .error_response = error_response });
         }
     }
 
     /// Handle resources/templates/list request
-    fn handleResourceTemplatesList(self: *Self, request: jsonrpc.Request) !void {
-        var templates_array: std.json.Array = .init(self.allocator);
+    fn handleResourceTemplatesList(self: *Self, io: std.Io, allocator: std.mem.Allocator, request: jsonrpc.Request) !void {
+        var templates_array: std.json.Array = .init(allocator);
 
         var iter = self.resource_templates.iterator();
         while (iter.next()) |entry| {
             var template_obj: std.json.ObjectMap = .empty;
-            try template_obj.put(self.allocator, "uriTemplate", .{ .string = entry.value_ptr.uriTemplate });
-            try template_obj.put(self.allocator, "name", .{ .string = entry.value_ptr.name });
+            try template_obj.put(allocator, "uriTemplate", .{ .string = entry.value_ptr.uriTemplate });
+            try template_obj.put(allocator, "name", .{ .string = entry.value_ptr.name });
             if (entry.value_ptr.title) |t| {
-                try template_obj.put(self.allocator, "title", .{ .string = t });
+                try template_obj.put(allocator, "title", .{ .string = t });
             }
             if (entry.value_ptr.description) |desc| {
-                try template_obj.put(self.allocator, "description", .{ .string = desc });
+                try template_obj.put(allocator, "description", .{ .string = desc });
             }
             if (entry.value_ptr.mimeType) |mime| {
-                try template_obj.put(self.allocator, "mimeType", .{ .string = mime });
+                try template_obj.put(allocator, "mimeType", .{ .string = mime });
             }
             try templates_array.append(.{ .object = template_obj });
         }
 
         var result: std.json.ObjectMap = .empty;
-        try result.put(self.allocator, "resourceTemplates", .{ .array = templates_array });
+        try result.put(allocator, "resourceTemplates", .{ .array = templates_array });
 
         const response = jsonrpc.createResponse(request.id, .{ .object = result });
-        try self.sendResponse(.{ .response = response });
+        try self.sendResponse(io, allocator, .{ .response = response });
     }
 
     /// Handle resources/subscribe request
-    fn handleSubscribe(self: *Self, request: jsonrpc.Request) !void {
+    fn handleSubscribe(self: *Self, io: std.Io, allocator: std.mem.Allocator, request: jsonrpc.Request) !void {
         _ = request.params;
         var result: std.json.ObjectMap = .empty;
-        defer result.deinit(self.allocator);
+        defer result.deinit(allocator);
         const response = jsonrpc.createResponse(request.id, .{ .object = result });
-        try self.sendResponse(.{ .response = response });
+        try self.sendResponse(io, allocator, .{ .response = response });
     }
 
     /// Handle resources/unsubscribe request
-    fn handleUnsubscribe(self: *Self, request: jsonrpc.Request) !void {
+    fn handleUnsubscribe(self: *Self, io: std.Io, allocator: std.mem.Allocator, request: jsonrpc.Request) !void {
         _ = request.params;
         var result: std.json.ObjectMap = .empty;
-        defer result.deinit(self.allocator);
+        defer result.deinit(allocator);
         const response = jsonrpc.createResponse(request.id, .{ .object = result });
-        try self.sendResponse(.{ .response = response });
+        try self.sendResponse(io, allocator, .{ .response = response });
     }
 
     /// Handle prompts/list request
-    fn handlePromptsList(self: *Self, request: jsonrpc.Request) !void {
-        var prompts_array: std.json.Array = .init(self.allocator);
+    fn handlePromptsList(self: *Self, io: std.Io, allocator: std.mem.Allocator, request: jsonrpc.Request) !void {
+        var prompts_array: std.json.Array = .init(allocator);
 
         var iter = self.prompts.iterator();
         while (iter.next()) |entry| {
             var prompt_obj: std.json.ObjectMap = .empty;
-            try prompt_obj.put(self.allocator, "name", .{ .string = entry.value_ptr.name });
+            try prompt_obj.put(allocator, "name", .{ .string = entry.value_ptr.name });
             if (entry.value_ptr.description) |desc| {
-                try prompt_obj.put(self.allocator, "description", .{ .string = desc });
+                try prompt_obj.put(allocator, "description", .{ .string = desc });
             }
             if (entry.value_ptr.title) |t| {
-                try prompt_obj.put(self.allocator, "title", .{ .string = t });
+                try prompt_obj.put(allocator, "title", .{ .string = t });
             }
 
             if (entry.value_ptr.arguments) |args| {
-                var args_array: std.json.Array = .init(self.allocator);
+                var args_array: std.json.Array = .init(allocator);
                 for (args) |arg| {
                     var arg_obj: std.json.ObjectMap = .empty;
-                    try arg_obj.put(self.allocator, "name", .{ .string = arg.name });
+                    try arg_obj.put(allocator, "name", .{ .string = arg.name });
                     if (arg.title) |t| {
-                        try arg_obj.put(self.allocator, "title", .{ .string = t });
+                        try arg_obj.put(allocator, "title", .{ .string = t });
                     }
                     if (arg.description) |d| {
-                        try arg_obj.put(self.allocator, "description", .{ .string = d });
+                        try arg_obj.put(allocator, "description", .{ .string = d });
                     }
-                    try arg_obj.put(self.allocator, "required", .{ .bool = arg.required });
+                    try arg_obj.put(allocator, "required", .{ .bool = arg.required });
                     try args_array.append(.{ .object = arg_obj });
                 }
-                try prompt_obj.put(self.allocator, "arguments", .{ .array = args_array });
+                try prompt_obj.put(allocator, "arguments", .{ .array = args_array });
             }
 
             try prompts_array.append(.{ .object = prompt_obj });
         }
 
         var result: std.json.ObjectMap = .empty;
-        try result.put(self.allocator, "prompts", .{ .array = prompts_array });
+        try result.put(allocator, "prompts", .{ .array = prompts_array });
 
         const response = jsonrpc.createResponse(request.id, .{ .object = result });
-        try self.sendResponse(.{ .response = response });
+        try self.sendResponse(io, allocator, .{ .response = response });
     }
 
     /// Handle prompts/get request
-    fn handlePromptsGet(self: *Self, request: jsonrpc.Request) !void {
+    fn handlePromptsGet(self: *Self, io: std.Io, allocator: std.mem.Allocator, request: jsonrpc.Request) !void {
         var prompt_name: []const u8 = "";
         var arguments: ?std.json.Value = null;
 
@@ -906,65 +883,65 @@ pub const Server = struct {
         }
 
         if (self.prompts.get(prompt_name)) |prompt| {
-            const messages = prompt.handler(self.allocator, arguments) catch |err| {
+            const messages = prompt.handler(allocator, arguments) catch |err| {
                 const error_response = jsonrpc.createInternalError(request.id, .{ .string = @errorName(err) });
-                try self.sendResponse(.{ .error_response = error_response });
+                try self.sendResponse(io, allocator, .{ .error_response = error_response });
                 return;
             };
 
-            var messages_array: std.json.Array = .init(self.allocator);
+            var messages_array: std.json.Array = .init(allocator);
             for (messages) |msg| {
                 var msg_obj: std.json.ObjectMap = .empty;
-                try msg_obj.put(self.allocator, "role", .{ .string = msg.role.toString() });
+                try msg_obj.put(allocator, "role", .{ .string = msg.role.toString() });
                 var content_obj: std.json.ObjectMap = .empty;
                 switch (msg.content) {
                     .text => |text| {
-                        try content_obj.put(self.allocator, "type", .{ .string = "text" });
-                        try content_obj.put(self.allocator, "text", .{ .string = text.text });
+                        try content_obj.put(allocator, "type", .{ .string = "text" });
+                        try content_obj.put(allocator, "text", .{ .string = text.text });
                     },
                     .image => |img| {
-                        try content_obj.put(self.allocator, "type", .{ .string = "image" });
-                        try content_obj.put(self.allocator, "data", .{ .string = img.data });
-                        try content_obj.put(self.allocator, "mimeType", .{ .string = img.mimeType });
+                        try content_obj.put(allocator, "type", .{ .string = "image" });
+                        try content_obj.put(allocator, "data", .{ .string = img.data });
+                        try content_obj.put(allocator, "mimeType", .{ .string = img.mimeType });
                     },
                     .audio => |aud| {
-                        try content_obj.put(self.allocator, "type", .{ .string = "audio" });
-                        try content_obj.put(self.allocator, "data", .{ .string = aud.data });
-                        try content_obj.put(self.allocator, "mimeType", .{ .string = aud.mimeType });
+                        try content_obj.put(allocator, "type", .{ .string = "audio" });
+                        try content_obj.put(allocator, "data", .{ .string = aud.data });
+                        try content_obj.put(allocator, "mimeType", .{ .string = aud.mimeType });
                     },
                     .resource_link => |link| {
-                        try content_obj.put(self.allocator, "type", .{ .string = "resource_link" });
-                        try content_obj.put(self.allocator, "uri", .{ .string = link.uri });
-                        try content_obj.put(self.allocator, "name", .{ .string = link.name });
+                        try content_obj.put(allocator, "type", .{ .string = "resource_link" });
+                        try content_obj.put(allocator, "uri", .{ .string = link.uri });
+                        try content_obj.put(allocator, "name", .{ .string = link.name });
                     },
                     .resource => |res| {
-                        try content_obj.put(self.allocator, "type", .{ .string = "resource" });
+                        try content_obj.put(allocator, "type", .{ .string = "resource" });
                         var res_inner: std.json.ObjectMap = .empty;
-                        try res_inner.put(self.allocator, "uri", .{ .string = res.resource.uri });
-                        if (res.resource.text) |text| try res_inner.put(self.allocator, "text", .{ .string = text });
-                        try content_obj.put(self.allocator, "resource", .{ .object = res_inner });
+                        try res_inner.put(allocator, "uri", .{ .string = res.resource.uri });
+                        if (res.resource.text) |text| try res_inner.put(allocator, "text", .{ .string = text });
+                        try content_obj.put(allocator, "resource", .{ .object = res_inner });
                     },
                 }
-                try msg_obj.put(self.allocator, "content", .{ .object = content_obj });
+                try msg_obj.put(allocator, "content", .{ .object = content_obj });
                 try messages_array.append(.{ .object = msg_obj });
             }
 
             var result: std.json.ObjectMap = .empty;
-            try result.put(self.allocator, "messages", .{ .array = messages_array });
+            try result.put(allocator, "messages", .{ .array = messages_array });
             if (prompt.description) |desc| {
-                try result.put(self.allocator, "description", .{ .string = desc });
+                try result.put(allocator, "description", .{ .string = desc });
             }
 
             const response = jsonrpc.createResponse(request.id, .{ .object = result });
-            try self.sendResponse(.{ .response = response });
+            try self.sendResponse(io, allocator, .{ .response = response });
         } else {
             const error_response = jsonrpc.createInvalidParams(request.id, "Prompt not found");
-            try self.sendResponse(.{ .error_response = error_response });
+            try self.sendResponse(io, allocator, .{ .error_response = error_response });
         }
     }
 
     /// Handle logging/setLevel request
-    fn handleSetLogLevel(self: *Self, request: jsonrpc.Request) !void {
+    fn handleSetLogLevel(self: *Self, io: std.Io, allocator: std.mem.Allocator, request: jsonrpc.Request) !void {
         if (request.params) |params| {
             if (params == .object) {
                 if (params.object.get("level")) |level_val| {
@@ -994,59 +971,59 @@ pub const Server = struct {
 
         const result: std.json.ObjectMap = .empty;
         const response = jsonrpc.createResponse(request.id, .{ .object = result });
-        try self.sendResponse(.{ .response = response });
+        try self.sendResponse(io, allocator, .{ .response = response });
     }
 
     /// Handle completion/complete request
-    fn handleCompletion(self: *Self, request: jsonrpc.Request) !void {
+    fn handleCompletion(self: *Self, io: std.Io, allocator: std.mem.Allocator, request: jsonrpc.Request) !void {
         var completion: std.json.ObjectMap = .empty;
-        const values_array: std.json.Array = .init(self.allocator);
-        try completion.put(self.allocator, "values", .{ .array = values_array });
-        try completion.put(self.allocator, "hasMore", .{ .bool = false });
+        const values_array: std.json.Array = .init(allocator);
+        try completion.put(allocator, "values", .{ .array = values_array });
+        try completion.put(allocator, "hasMore", .{ .bool = false });
 
         var result: std.json.ObjectMap = .empty;
-        try result.put(self.allocator, "completion", .{ .object = completion });
+        try result.put(allocator, "completion", .{ .object = completion });
 
         const response = jsonrpc.createResponse(request.id, .{ .object = result });
-        try self.sendResponse(.{ .response = response });
+        try self.sendResponse(io, allocator, .{ .response = response });
     }
 
     /// Handle tasks/get request
-    fn handleTasksGet(self: *Self, request: jsonrpc.Request) !void {
+    fn handleTasksGet(self: *Self, io: std.Io, allocator: std.mem.Allocator, request: jsonrpc.Request) !void {
         _ = request.params;
         const error_response = jsonrpc.createMethodNotFound(request.id, "tasks/get");
-        try self.sendResponse(.{ .error_response = error_response });
+        try self.sendResponse(io, allocator, .{ .error_response = error_response });
     }
 
     /// Handle tasks/result request
-    fn handleTasksResult(self: *Self, request: jsonrpc.Request) !void {
+    fn handleTasksResult(self: *Self, io: std.Io, allocator: std.mem.Allocator, request: jsonrpc.Request) !void {
         _ = request.params;
         const error_response = jsonrpc.createMethodNotFound(request.id, "tasks/result");
-        try self.sendResponse(.{ .error_response = error_response });
+        try self.sendResponse(io, allocator, .{ .error_response = error_response });
     }
 
     /// Handle tasks/list request
-    fn handleTasksList(self: *Self, request: jsonrpc.Request) !void {
+    fn handleTasksList(self: *Self, io: std.Io, allocator: std.mem.Allocator, request: jsonrpc.Request) !void {
         var result: std.json.ObjectMap = .empty;
-        const tasks_array: std.json.Array = .init(self.allocator);
-        try result.put(self.allocator, "tasks", .{ .array = tasks_array });
+        const tasks_array: std.json.Array = .init(allocator);
+        try result.put(allocator, "tasks", .{ .array = tasks_array });
 
         const response = jsonrpc.createResponse(request.id, .{ .object = result });
-        try self.sendResponse(.{ .response = response });
+        try self.sendResponse(io, allocator, .{ .response = response });
     }
 
     /// Handle tasks/cancel request
-    fn handleTasksCancel(self: *Self, request: jsonrpc.Request) !void {
+    fn handleTasksCancel(self: *Self, io: std.Io, allocator: std.mem.Allocator, request: jsonrpc.Request) !void {
         _ = request.params;
         const error_response = jsonrpc.createMethodNotFound(request.id, "tasks/cancel");
-        try self.sendResponse(.{ .error_response = error_response });
+        try self.sendResponse(io, allocator, .{ .error_response = error_response });
     }
 
     /// Handle incoming notifications
-    fn handleNotification(self: *Self, notification: jsonrpc.Notification) !void {
+    fn handleNotification(self: *Self, io: std.Io, notification: jsonrpc.Notification) !void {
         if (std.mem.eql(u8, notification.method, "notifications/initialized")) {
             self.state = .ready;
-            self.log("Server initialized and ready");
+            self.log(io, "Server initialized and ready");
         } else if (std.mem.eql(u8, notification.method, "notifications/cancelled")) {
             if (notification.params) |params| {
                 if (params == .object) {
@@ -1056,7 +1033,7 @@ pub const Server = struct {
                 }
             }
         } else if (std.mem.eql(u8, notification.method, "notifications/roots/list_changed")) {
-            self.log("Roots list changed");
+            self.log(io, "Roots list changed");
         }
     }
 
@@ -1070,7 +1047,7 @@ pub const Server = struct {
     }
 
     /// Handle incoming error response
-    fn handleErrorResponse(self: *Self, err: jsonrpc.ErrorResponse) void {
+    fn handleErrorResponse(self: *Self, io: std.Io, err: jsonrpc.ErrorResponse) void {
         if (err.id) |id| {
             const int_id = switch (id) {
                 .integer => |i| i,
@@ -1078,97 +1055,96 @@ pub const Server = struct {
             };
             _ = self.pending_requests.remove(int_id);
         }
-        self.logError(err.@"error".message);
+        self.logError(io, err.@"error".message);
     }
 
     /// Send a notification to the client
-    pub fn sendNotification(self: *Self, method: []const u8, params: ?std.json.Value) !void {
+    pub fn sendNotification(self: *Self, io: std.Io, allocator: std.mem.Allocator, method: []const u8, params: ?std.json.Value) !void {
         const notification = jsonrpc.createNotification(method, params);
-        try self.sendResponse(.{ .notification = notification });
+        try self.sendResponse(io, allocator, .{ .notification = notification });
     }
 
     /// Send a log message notification
-    pub fn sendLogMessage(self: *Self, level: protocol.LogLevel, message: []const u8) !void {
+    pub fn sendLogMessage(self: *Self, io: std.Io, allocator: std.mem.Allocator, level: protocol.LogLevel, message: []const u8) !void {
         if (@intFromEnum(level) < @intFromEnum(self.log_level)) return;
 
         var params: std.json.ObjectMap = .empty;
-        try params.put(self.allocator, "level", .{ .string = level.toString() });
-        try params.put(self.allocator, "data", .{ .string = message });
+        try params.put(allocator, "level", .{ .string = level.toString() });
+        try params.put(allocator, "data", .{ .string = message });
 
-        try self.sendNotification("notifications/message", .{ .object = params });
+        try self.sendNotification(io, allocator, "notifications/message", .{ .object = params });
     }
 
     /// Send a progress notification
-    pub fn sendProgress(self: *Self, token: std.json.Value, prog: f64, total: ?f64, message: ?[]const u8) !void {
+    pub fn sendProgress(self: *Self, io: std.Io, allocator: std.mem.Allocator, token: std.json.Value, prog: f64, total: ?f64, message: ?[]const u8) !void {
         var params: std.json.ObjectMap = .empty;
-        try params.put(self.allocator, "progressToken", token);
-        try params.put(self.allocator, "progress", .{ .float = prog });
+        try params.put(allocator, "progressToken", token);
+        try params.put(allocator, "progress", .{ .float = prog });
         if (total) |t| {
-            try params.put(self.allocator, "total", .{ .float = t });
+            try params.put(allocator, "total", .{ .float = t });
         }
         if (message) |m| {
-            try params.put(self.allocator, "message", .{ .string = m });
+            try params.put(allocator, "message", .{ .string = m });
         }
-        try self.sendNotification("notifications/progress", .{ .object = params });
+        try self.sendNotification(io, allocator, "notifications/progress", .{ .object = params });
     }
 
     /// Notify clients that tools have changed
-    pub fn notifyToolsChanged(self: *Self) !void {
-        try self.sendNotification("notifications/tools/list_changed", null);
+    pub fn notifyToolsChanged(self: *Self, io: std.Io, allocator: std.mem.Allocator) !void {
+        try self.sendNotification(io, allocator, "notifications/tools/list_changed", null);
     }
 
     /// Notify clients that resources have changed
-    pub fn notifyResourcesChanged(self: *Self) !void {
-        try self.sendNotification("notifications/resources/list_changed", null);
+    pub fn notifyResourcesChanged(self: *Self, io: std.Io, allocator: std.mem.Allocator) !void {
+        try self.sendNotification(io, allocator, "notifications/resources/list_changed", null);
     }
 
     /// Notify clients that a resource has been updated
-    pub fn notifyResourceUpdated(self: *Self, uri: []const u8) !void {
+    pub fn notifyResourceUpdated(self: *Self, io: std.Io, allocator: std.mem.Allocator, uri: []const u8) !void {
         var params: std.json.ObjectMap = .empty;
-        try params.put(self.allocator, "uri", .{ .string = uri });
-        try self.sendNotification("notifications/resources/updated", .{ .object = params });
+        try params.put(allocator, "uri", .{ .string = uri });
+        try self.sendNotification(io, allocator, "notifications/resources/updated", .{ .object = params });
     }
 
     /// Notify clients that prompts have changed
-    pub fn notifyPromptsChanged(self: *Self) !void {
-        try self.sendNotification("notifications/prompts/list_changed", null);
+    pub fn notifyPromptsChanged(self: *Self, io: std.Io, allocator: std.mem.Allocator) !void {
+        try self.sendNotification(io, allocator, "notifications/prompts/list_changed", null);
     }
 
     /// Send a response message
-    fn sendResponse(self: *Self, message: jsonrpc.Message) !void {
+    fn sendResponse(self: *Self, io: std.Io, allocator: std.mem.Allocator, message: jsonrpc.Message) !void {
         if (self.transport) |t| {
-            const json = jsonrpc.serializeMessage(self.allocator, message) catch {
-                self.logError("Failed to serialize response");
+            const json = jsonrpc.serializeMessage(allocator, message) catch {
+                self.logError(io, "Failed to serialize response");
                 return;
             };
-            defer self.allocator.free(json);
-            t.send(json) catch {
-                self.logError("Failed to send response");
+            defer allocator.free(json);
+            t.send(io, allocator, json) catch {
+                self.logError(io, "Failed to send response");
                 return;
             };
         }
     }
 
-    fn log(self: *Self, message: []const u8) void {
+    fn log(self: *Self, io: std.Io, message: []const u8) void {
         if (self.stdio_transport) |t| {
-            t.writeStderr(message);
+            t.writeStderr(io, message);
         }
     }
 
-    fn logError(self: *Self, message: []const u8) void {
+    fn logError(self: *Self, io: std.Io, message: []const u8) void {
         if (self.stdio_transport) |t| {
             var buf: [512]u8 = undefined;
             const formatted = std.fmt.bufPrint(&buf, "ERROR: {s}", .{message}) catch message;
-            t.writeStderr(formatted);
+            t.writeStderr(io, formatted);
         }
     }
 };
 
 test "Server initialization" {
-    var server: Server = .init(.{
+    var server: Server = .init(std.testing.allocator, .{
         .name = "test-server",
         .version = "1.0.0",
-        .allocator = std.testing.allocator,
     });
     defer server.deinit();
 
@@ -1177,10 +1153,9 @@ test "Server initialization" {
 }
 
 test "Server add tool" {
-    var server: Server = .init(.{
+    var server: Server = .init(std.testing.allocator, .{
         .name = "test-server",
         .version = "1.0.0",
-        .allocator = std.testing.allocator,
     });
     defer server.deinit();
 
@@ -1200,10 +1175,9 @@ test "Server add tool" {
 }
 
 test "Server add resource" {
-    var server: Server = .init(.{
+    var server: Server = .init(std.testing.allocator, .{
         .name = "test-server",
         .version = "1.0.0",
-        .allocator = std.testing.allocator,
     });
     defer server.deinit();
 
@@ -1221,10 +1195,9 @@ test "Server add resource" {
 }
 
 test "Server add prompt" {
-    var server: Server = .init(.{
+    var server: Server = .init(std.testing.allocator, .{
         .name = "test-server",
         .version = "1.0.0",
-        .allocator = std.testing.allocator,
     });
     defer server.deinit();
 
@@ -1242,10 +1215,9 @@ test "Server add prompt" {
 }
 
 test "Server enable capabilities" {
-    var server: Server = .init(.{
+    var server: Server = .init(std.testing.allocator, .{
         .name = "test-server",
         .version = "1.0.0",
-        .allocator = std.testing.allocator,
     });
     defer server.deinit();
 

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -89,6 +89,7 @@ pub const ServerConfig = struct {
     websiteUrl: ?[]const u8 = null,
     instructions: ?[]const u8 = null,
     allocator: std.mem.Allocator = std.heap.page_allocator,
+    io: ?std.Io = null,
 };
 
 /// Current state of the server
@@ -104,6 +105,7 @@ pub const ServerState = enum {
 pub const Server = struct {
     config: ServerConfig,
     allocator: std.mem.Allocator,
+    io: std.Io,
     state: ServerState = .uninitialized,
     tools: std.StringHashMap(tools_mod.Tool),
     resources: std.StringHashMap(resources_mod.Resource),
@@ -129,9 +131,15 @@ pub const Server = struct {
     /// Initialize a new MCP Server
     pub fn init(config: ServerConfig) Self {
         const allocator = config.allocator;
+        const io = config.io orelse io: {
+            var threaded: std.Io.Threaded = .init_single_threaded;
+            break :io threaded.io();
+        };
+
         return .{
             .config = config,
             .allocator = allocator,
+            .io = io,
             .tools = std.StringHashMap(tools_mod.Tool).init(allocator),
             .resources = std.StringHashMap(resources_mod.Resource).init(allocator),
             .resource_templates = std.StringHashMap(resources_mod.ResourceTemplate).init(allocator),
@@ -220,7 +228,7 @@ pub const Server = struct {
             .stdio => {
                 self.log("Server listening on STDIO");
                 const stdio = try self.allocator.create(transport_mod.StdioTransport);
-                stdio.* = transport_mod.StdioTransport.init(self.allocator);
+                stdio.* = transport_mod.StdioTransport.init(self.io, self.allocator);
                 self.stdio_transport = stdio;
                 self.transport = stdio.transport();
                 try self.messageLoop();
@@ -232,37 +240,36 @@ pub const Server = struct {
     }
 
     fn runHttp(self: *Self, config: HttpRunConfig) !void {
+        const io = self.io;
         const bind_host = if (std.mem.eql(u8, config.host, "localhost")) "127.0.0.1" else config.host;
 
-        const address = std.net.Address.resolveIp(bind_host, config.port) catch {
+        const address = std.Io.net.IpAddress.resolve(io, bind_host, config.port) catch {
             return error.AddressResolutionError;
         };
 
-        var listener = try address.listen(.{ .reuse_address = true });
-        defer listener.deinit();
-
-        std.log.info("Server listening on http://{f}", .{listener.listen_address});
+        var listener = try std.Io.net.IpAddress.listen(&address, io, .{});
+        defer listener.deinit(io);
 
         while (self.state != .stopped and self.state != .shutting_down) {
-            const connection = listener.accept() catch |err| {
+            const stream = listener.accept(io) catch |err| {
                 std.log.err("HTTP accept failed: {s}", .{@errorName(err)});
                 continue;
             };
 
-            self.serveHttpConnection(connection) catch |err| {
+            self.serveHttpConnection(io, stream) catch |err| {
                 std.log.err("HTTP connection error: {s}", .{@errorName(err)});
             };
         }
     }
 
-    fn serveHttpConnection(self: *Self, connection: std.net.Server.Connection) !void {
-        defer connection.stream.close();
+    fn serveHttpConnection(self: *Self, io: std.Io, stream: std.Io.net.Stream) !void {
+        defer stream.close(io);
 
         var send_buffer: [4096]u8 = undefined;
         var recv_buffer: [4096]u8 = undefined;
-        var connection_reader = connection.stream.reader(&recv_buffer);
-        var connection_writer = connection.stream.writer(&send_buffer);
-        var server: http.Server = .init(connection_reader.interface(), &connection_writer.interface);
+        var connection_reader = stream.reader(io, &recv_buffer);
+        var connection_writer = stream.writer(io, &send_buffer);
+        var server: http.Server = .init(&connection_reader.interface, &connection_writer.interface);
 
         var request = server.receiveHead() catch |err| switch (err) {
             error.HttpConnectionClosing => return,

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -6,13 +6,14 @@
 
 const std = @import("std");
 const http = std.http;
-const protocol = @import("../protocol/protocol.zig");
+
 const jsonrpc = @import("../protocol/jsonrpc.zig");
+const protocol = @import("../protocol/protocol.zig");
 const types = @import("../protocol/types.zig");
 const transport_mod = @import("../transport/transport.zig");
-const tools_mod = @import("tools.zig");
-const resources_mod = @import("resources.zig");
 const prompts_mod = @import("prompts.zig");
+const resources_mod = @import("resources.zig");
+const tools_mod = @import("tools.zig");
 
 const HttpRequestTransport = struct {
     allocator: std.mem.Allocator,
@@ -511,63 +512,63 @@ pub const Server = struct {
             }
         }
 
-        var result = std.json.ObjectMap.init(self.allocator);
-        defer result.deinit();
+        var result: std.json.ObjectMap = .empty;
+        defer result.deinit(self.allocator);
 
-        try result.put("protocolVersion", .{ .string = protocol.VERSION });
+        try result.put(self.allocator, "protocolVersion", .{ .string = protocol.VERSION });
 
-        var caps = std.json.ObjectMap.init(self.allocator);
+        var caps: std.json.ObjectMap = .empty;
         if (self.capabilities.tools) |t| {
-            var tools_cap = std.json.ObjectMap.init(self.allocator);
-            try tools_cap.put("listChanged", .{ .bool = t.listChanged });
-            try caps.put("tools", .{ .object = tools_cap });
+            var tools_cap: std.json.ObjectMap = .empty;
+            try tools_cap.put(self.allocator, "listChanged", .{ .bool = t.listChanged });
+            try caps.put(self.allocator, "tools", .{ .object = tools_cap });
         }
         if (self.capabilities.resources) |r| {
-            var res_cap = std.json.ObjectMap.init(self.allocator);
-            try res_cap.put("listChanged", .{ .bool = r.listChanged });
-            try res_cap.put("subscribe", .{ .bool = r.subscribe });
-            try caps.put("resources", .{ .object = res_cap });
+            var res_cap: std.json.ObjectMap = .empty;
+            try res_cap.put(self.allocator, "listChanged", .{ .bool = r.listChanged });
+            try res_cap.put(self.allocator, "subscribe", .{ .bool = r.subscribe });
+            try caps.put(self.allocator, "resources", .{ .object = res_cap });
         }
         if (self.capabilities.prompts) |p| {
-            var prompts_cap = std.json.ObjectMap.init(self.allocator);
-            try prompts_cap.put("listChanged", .{ .bool = p.listChanged });
-            try caps.put("prompts", .{ .object = prompts_cap });
+            var prompts_cap: std.json.ObjectMap = .empty;
+            try prompts_cap.put(self.allocator, "listChanged", .{ .bool = p.listChanged });
+            try caps.put(self.allocator, "prompts", .{ .object = prompts_cap });
         }
         if (self.capabilities.logging != null) {
-            try caps.put("logging", .{ .object = std.json.ObjectMap.init(self.allocator) });
+            try caps.put(self.allocator, "logging", .{ .object = .empty });
         }
         if (self.capabilities.completions != null) {
-            try caps.put("completions", .{ .object = std.json.ObjectMap.init(self.allocator) });
+            try caps.put(self.allocator, "completions", .{ .object = .empty });
         }
         if (self.capabilities.tasks != null) {
-            var tasks_cap = std.json.ObjectMap.init(self.allocator);
-            try tasks_cap.put("list", .{ .object = std.json.ObjectMap.init(self.allocator) });
-            try tasks_cap.put("cancel", .{ .object = std.json.ObjectMap.init(self.allocator) });
-            var requests_cap = std.json.ObjectMap.init(self.allocator);
-            var tools_req = std.json.ObjectMap.init(self.allocator);
-            try tools_req.put("call", .{ .object = std.json.ObjectMap.init(self.allocator) });
-            try requests_cap.put("tools", .{ .object = tools_req });
-            try tasks_cap.put("requests", .{ .object = requests_cap });
-            try caps.put("tasks", .{ .object = tasks_cap });
+            var tasks_cap: std.json.ObjectMap = .empty;
+            try tasks_cap.put(self.allocator, "list", .{ .object = .empty });
+            try tasks_cap.put(self.allocator, "cancel", .{ .object = .empty });
+            var requests_cap: std.json.ObjectMap = .empty;
+            var tools_req: std.json.ObjectMap = .empty;
+            try tools_req.put(self.allocator, "call", .{ .object = .empty });
+            try requests_cap.put(self.allocator, "tools", .{ .object = tools_req });
+            try tasks_cap.put(self.allocator, "requests", .{ .object = requests_cap });
+            try caps.put(self.allocator, "tasks", .{ .object = tasks_cap });
         }
-        try result.put("capabilities", .{ .object = caps });
+        try result.put(self.allocator, "capabilities", .{ .object = caps });
 
-        var server_info = std.json.ObjectMap.init(self.allocator);
-        try server_info.put("name", .{ .string = self.config.name });
-        try server_info.put("version", .{ .string = self.config.version });
+        var server_info: std.json.ObjectMap = .empty;
+        try server_info.put(self.allocator, "name", .{ .string = self.config.name });
+        try server_info.put(self.allocator, "version", .{ .string = self.config.version });
         if (self.config.title) |t| {
-            try server_info.put("title", .{ .string = t });
+            try server_info.put(self.allocator, "title", .{ .string = t });
         }
         if (self.config.description) |d| {
-            try server_info.put("description", .{ .string = d });
+            try server_info.put(self.allocator, "description", .{ .string = d });
         }
         if (self.config.websiteUrl) |u| {
-            try server_info.put("websiteUrl", .{ .string = u });
+            try server_info.put(self.allocator, "websiteUrl", .{ .string = u });
         }
-        try result.put("serverInfo", .{ .object = server_info });
+        try result.put(self.allocator, "serverInfo", .{ .object = server_info });
 
         if (self.config.instructions) |inst| {
-            try result.put("instructions", .{ .string = inst });
+            try result.put(self.allocator, "instructions", .{ .string = inst });
         }
 
         const response = jsonrpc.createResponse(request.id, .{ .object = result });
@@ -576,8 +577,8 @@ pub const Server = struct {
 
     /// Handle ping request
     fn handlePing(self: *Self, request: jsonrpc.Request) !void {
-        var result = std.json.ObjectMap.init(self.allocator);
-        defer result.deinit();
+        var result: std.json.ObjectMap = .empty;
+        defer result.deinit(self.allocator);
 
         const response = jsonrpc.createResponse(request.id, .{ .object = result });
         try self.sendResponse(.{ .response = response });
@@ -589,42 +590,42 @@ pub const Server = struct {
 
         var iter = self.tools.iterator();
         while (iter.next()) |entry| {
-            var tool_obj = std.json.ObjectMap.init(self.allocator);
-            try tool_obj.put("name", .{ .string = entry.value_ptr.name });
+            var tool_obj: std.json.ObjectMap = .empty;
+            try tool_obj.put(self.allocator, "name", .{ .string = entry.value_ptr.name });
             if (entry.value_ptr.description) |desc| {
-                try tool_obj.put("description", .{ .string = desc });
+                try tool_obj.put(self.allocator, "description", .{ .string = desc });
             }
             if (entry.value_ptr.title) |t| {
-                try tool_obj.put("title", .{ .string = t });
+                try tool_obj.put(self.allocator, "title", .{ .string = t });
             }
 
-            var input_schema = std.json.ObjectMap.init(self.allocator);
-            try input_schema.put("type", .{ .string = "object" });
-            try tool_obj.put("inputSchema", .{ .object = input_schema });
+            var input_schema: std.json.ObjectMap = .empty;
+            try input_schema.put(self.allocator, "type", .{ .string = "object" });
+            try tool_obj.put(self.allocator, "inputSchema", .{ .object = input_schema });
 
             if (entry.value_ptr.annotations) |ann| {
-                var ann_obj = std.json.ObjectMap.init(self.allocator);
-                if (ann.title) |t| try ann_obj.put("title", .{ .string = t });
-                try ann_obj.put("readOnlyHint", .{ .bool = ann.readOnlyHint });
-                try ann_obj.put("destructiveHint", .{ .bool = ann.destructiveHint });
-                try ann_obj.put("idempotentHint", .{ .bool = ann.idempotentHint });
-                try ann_obj.put("openWorldHint", .{ .bool = ann.openWorldHint });
-                try tool_obj.put("annotations", .{ .object = ann_obj });
+                var ann_obj: std.json.ObjectMap = .empty;
+                if (ann.title) |t| try ann_obj.put(self.allocator, "title", .{ .string = t });
+                try ann_obj.put(self.allocator, "readOnlyHint", .{ .bool = ann.readOnlyHint });
+                try ann_obj.put(self.allocator, "destructiveHint", .{ .bool = ann.destructiveHint });
+                try ann_obj.put(self.allocator, "idempotentHint", .{ .bool = ann.idempotentHint });
+                try ann_obj.put(self.allocator, "openWorldHint", .{ .bool = ann.openWorldHint });
+                try tool_obj.put(self.allocator, "annotations", .{ .object = ann_obj });
             }
 
             if (entry.value_ptr.execution) |exec| {
-                var exec_obj = std.json.ObjectMap.init(self.allocator);
+                var exec_obj: std.json.ObjectMap = .empty;
                 if (exec.taskSupport) |ts| {
-                    try exec_obj.put("taskSupport", .{ .string = ts });
+                    try exec_obj.put(self.allocator, "taskSupport", .{ .string = ts });
                 }
-                try tool_obj.put("execution", .{ .object = exec_obj });
+                try tool_obj.put(self.allocator, "execution", .{ .object = exec_obj });
             }
 
             try tools_array.append(.{ .object = tool_obj });
         }
 
-        var result = std.json.ObjectMap.init(self.allocator);
-        try result.put("tools", .{ .array = tools_array });
+        var result: std.json.ObjectMap = .empty;
+        try result.put(self.allocator, "tools", .{ .array = tools_array });
 
         const response = jsonrpc.createResponse(request.id, .{ .object = result });
         try self.sendResponse(.{ .response = response });
@@ -649,14 +650,14 @@ pub const Server = struct {
         if (self.tools.get(tool_name)) |tool| {
             const tool_result = tool.handler(self.allocator, arguments) catch |err| {
                 var content_array = std.json.Array.init(self.allocator);
-                var text_obj = std.json.ObjectMap.init(self.allocator);
-                try text_obj.put("type", .{ .string = "text" });
-                try text_obj.put("text", .{ .string = @errorName(err) });
+                var text_obj: std.json.ObjectMap = .empty;
+                try text_obj.put(self.allocator, "type", .{ .string = "text" });
+                try text_obj.put(self.allocator, "text", .{ .string = @errorName(err) });
                 try content_array.append(.{ .object = text_obj });
 
-                var result = std.json.ObjectMap.init(self.allocator);
-                try result.put("content", .{ .array = content_array });
-                try result.put("isError", .{ .bool = true });
+                var result: std.json.ObjectMap = .empty;
+                try result.put(self.allocator, "content", .{ .array = content_array });
+                try result.put(self.allocator, "isError", .{ .bool = true });
 
                 const response = jsonrpc.createResponse(request.id, .{ .object = result });
                 try self.sendResponse(.{ .response = response });
@@ -665,47 +666,47 @@ pub const Server = struct {
 
             var content_array = std.json.Array.init(self.allocator);
             for (tool_result.content) |content_item| {
-                var item_obj = std.json.ObjectMap.init(self.allocator);
+                var item_obj: std.json.ObjectMap = .empty;
                 switch (content_item) {
                     .text => |text| {
-                        try item_obj.put("type", .{ .string = "text" });
-                        try item_obj.put("text", .{ .string = text.text });
+                        try item_obj.put(self.allocator, "type", .{ .string = "text" });
+                        try item_obj.put(self.allocator, "text", .{ .string = text.text });
                     },
                     .image => |img| {
-                        try item_obj.put("type", .{ .string = "image" });
-                        try item_obj.put("data", .{ .string = img.data });
-                        try item_obj.put("mimeType", .{ .string = img.mimeType });
+                        try item_obj.put(self.allocator, "type", .{ .string = "image" });
+                        try item_obj.put(self.allocator, "data", .{ .string = img.data });
+                        try item_obj.put(self.allocator, "mimeType", .{ .string = img.mimeType });
                     },
                     .audio => |aud| {
-                        try item_obj.put("type", .{ .string = "audio" });
-                        try item_obj.put("data", .{ .string = aud.data });
-                        try item_obj.put("mimeType", .{ .string = aud.mimeType });
+                        try item_obj.put(self.allocator, "type", .{ .string = "audio" });
+                        try item_obj.put(self.allocator, "data", .{ .string = aud.data });
+                        try item_obj.put(self.allocator, "mimeType", .{ .string = aud.mimeType });
                     },
                     .resource_link => |link| {
-                        try item_obj.put("type", .{ .string = "resource_link" });
-                        try item_obj.put("uri", .{ .string = link.uri });
-                        try item_obj.put("name", .{ .string = link.name });
-                        if (link.title) |t| try item_obj.put("title", .{ .string = t });
-                        if (link.description) |d| try item_obj.put("description", .{ .string = d });
-                        if (link.mimeType) |m| try item_obj.put("mimeType", .{ .string = m });
+                        try item_obj.put(self.allocator, "type", .{ .string = "resource_link" });
+                        try item_obj.put(self.allocator, "uri", .{ .string = link.uri });
+                        try item_obj.put(self.allocator, "name", .{ .string = link.name });
+                        if (link.title) |t| try item_obj.put(self.allocator, "title", .{ .string = t });
+                        if (link.description) |d| try item_obj.put(self.allocator, "description", .{ .string = d });
+                        if (link.mimeType) |m| try item_obj.put(self.allocator, "mimeType", .{ .string = m });
                     },
                     .resource => |res| {
-                        try item_obj.put("type", .{ .string = "resource" });
-                        var res_obj = std.json.ObjectMap.init(self.allocator);
-                        try res_obj.put("uri", .{ .string = res.resource.uri });
-                        if (res.resource.text) |text| try res_obj.put("text", .{ .string = text });
-                        if (res.resource.mimeType) |mime| try res_obj.put("mimeType", .{ .string = mime });
-                        try item_obj.put("resource", .{ .object = res_obj });
+                        try item_obj.put(self.allocator, "type", .{ .string = "resource" });
+                        var res_obj: std.json.ObjectMap = .empty;
+                        try res_obj.put(self.allocator, "uri", .{ .string = res.resource.uri });
+                        if (res.resource.text) |text| try res_obj.put(self.allocator, "text", .{ .string = text });
+                        if (res.resource.mimeType) |mime| try res_obj.put(self.allocator, "mimeType", .{ .string = mime });
+                        try item_obj.put(self.allocator, "resource", .{ .object = res_obj });
                     },
                 }
                 try content_array.append(.{ .object = item_obj });
             }
 
-            var result = std.json.ObjectMap.init(self.allocator);
-            try result.put("content", .{ .array = content_array });
-            try result.put("isError", .{ .bool = tool_result.is_error });
+            var result: std.json.ObjectMap = .empty;
+            try result.put(self.allocator, "content", .{ .array = content_array });
+            try result.put(self.allocator, "isError", .{ .bool = tool_result.is_error });
             if (tool_result.structuredContent) |sc| {
-                try result.put("structuredContent", sc);
+                try result.put(self.allocator, "structuredContent", sc);
             }
 
             const response = jsonrpc.createResponse(request.id, .{ .object = result });
@@ -722,26 +723,26 @@ pub const Server = struct {
 
         var iter = self.resources.iterator();
         while (iter.next()) |entry| {
-            var resource_obj = std.json.ObjectMap.init(self.allocator);
-            try resource_obj.put("uri", .{ .string = entry.value_ptr.uri });
-            try resource_obj.put("name", .{ .string = entry.value_ptr.name });
+            var resource_obj: std.json.ObjectMap = .empty;
+            try resource_obj.put(self.allocator, "uri", .{ .string = entry.value_ptr.uri });
+            try resource_obj.put(self.allocator, "name", .{ .string = entry.value_ptr.name });
             if (entry.value_ptr.title) |t| {
-                try resource_obj.put("title", .{ .string = t });
+                try resource_obj.put(self.allocator, "title", .{ .string = t });
             }
             if (entry.value_ptr.description) |desc| {
-                try resource_obj.put("description", .{ .string = desc });
+                try resource_obj.put(self.allocator, "description", .{ .string = desc });
             }
             if (entry.value_ptr.mimeType) |mime| {
-                try resource_obj.put("mimeType", .{ .string = mime });
+                try resource_obj.put(self.allocator, "mimeType", .{ .string = mime });
             }
             if (entry.value_ptr.size) |s| {
-                try resource_obj.put("size", .{ .integer = @intCast(s) });
+                try resource_obj.put(self.allocator, "size", .{ .integer = @intCast(s) });
             }
             try resources_array.append(.{ .object = resource_obj });
         }
 
-        var result = std.json.ObjectMap.init(self.allocator);
-        try result.put("resources", .{ .array = resources_array });
+        var result: std.json.ObjectMap = .empty;
+        try result.put(self.allocator, "resources", .{ .array = resources_array });
 
         const response = jsonrpc.createResponse(request.id, .{ .object = result });
         try self.sendResponse(.{ .response = response });
@@ -769,21 +770,21 @@ pub const Server = struct {
             };
 
             var contents_array = std.json.Array.init(self.allocator);
-            var content_obj = std.json.ObjectMap.init(self.allocator);
-            try content_obj.put("uri", .{ .string = uri });
+            var content_obj: std.json.ObjectMap = .empty;
+            try content_obj.put(self.allocator, "uri", .{ .string = uri });
             if (content.text) |text| {
-                try content_obj.put("text", .{ .string = text });
+                try content_obj.put(self.allocator, "text", .{ .string = text });
             }
             if (content.blob) |blob| {
-                try content_obj.put("blob", .{ .string = blob });
+                try content_obj.put(self.allocator, "blob", .{ .string = blob });
             }
             if (content.mimeType) |mime| {
-                try content_obj.put("mimeType", .{ .string = mime });
+                try content_obj.put(self.allocator, "mimeType", .{ .string = mime });
             }
             try contents_array.append(.{ .object = content_obj });
 
-            var result = std.json.ObjectMap.init(self.allocator);
-            try result.put("contents", .{ .array = contents_array });
+            var result: std.json.ObjectMap = .empty;
+            try result.put(self.allocator, "contents", .{ .array = contents_array });
 
             const response = jsonrpc.createResponse(request.id, .{ .object = result });
             try self.sendResponse(.{ .response = response });
@@ -799,23 +800,23 @@ pub const Server = struct {
 
         var iter = self.resource_templates.iterator();
         while (iter.next()) |entry| {
-            var template_obj = std.json.ObjectMap.init(self.allocator);
-            try template_obj.put("uriTemplate", .{ .string = entry.value_ptr.uriTemplate });
-            try template_obj.put("name", .{ .string = entry.value_ptr.name });
+            var template_obj: std.json.ObjectMap = .empty;
+            try template_obj.put(self.allocator, "uriTemplate", .{ .string = entry.value_ptr.uriTemplate });
+            try template_obj.put(self.allocator, "name", .{ .string = entry.value_ptr.name });
             if (entry.value_ptr.title) |t| {
-                try template_obj.put("title", .{ .string = t });
+                try template_obj.put(self.allocator, "title", .{ .string = t });
             }
             if (entry.value_ptr.description) |desc| {
-                try template_obj.put("description", .{ .string = desc });
+                try template_obj.put(self.allocator, "description", .{ .string = desc });
             }
             if (entry.value_ptr.mimeType) |mime| {
-                try template_obj.put("mimeType", .{ .string = mime });
+                try template_obj.put(self.allocator, "mimeType", .{ .string = mime });
             }
             try templates_array.append(.{ .object = template_obj });
         }
 
-        var result = std.json.ObjectMap.init(self.allocator);
-        try result.put("resourceTemplates", .{ .array = templates_array });
+        var result: std.json.ObjectMap = .empty;
+        try result.put(self.allocator, "resourceTemplates", .{ .array = templates_array });
 
         const response = jsonrpc.createResponse(request.id, .{ .object = result });
         try self.sendResponse(.{ .response = response });
@@ -824,8 +825,8 @@ pub const Server = struct {
     /// Handle resources/subscribe request
     fn handleSubscribe(self: *Self, request: jsonrpc.Request) !void {
         _ = request.params;
-        var result = std.json.ObjectMap.init(self.allocator);
-        defer result.deinit();
+        var result: std.json.ObjectMap = .empty;
+        defer result.deinit(self.allocator);
         const response = jsonrpc.createResponse(request.id, .{ .object = result });
         try self.sendResponse(.{ .response = response });
     }
@@ -833,8 +834,8 @@ pub const Server = struct {
     /// Handle resources/unsubscribe request
     fn handleUnsubscribe(self: *Self, request: jsonrpc.Request) !void {
         _ = request.params;
-        var result = std.json.ObjectMap.init(self.allocator);
-        defer result.deinit();
+        var result: std.json.ObjectMap = .empty;
+        defer result.deinit(self.allocator);
         const response = jsonrpc.createResponse(request.id, .{ .object = result });
         try self.sendResponse(.{ .response = response });
     }
@@ -845,37 +846,37 @@ pub const Server = struct {
 
         var iter = self.prompts.iterator();
         while (iter.next()) |entry| {
-            var prompt_obj = std.json.ObjectMap.init(self.allocator);
-            try prompt_obj.put("name", .{ .string = entry.value_ptr.name });
+            var prompt_obj: std.json.ObjectMap = .empty;
+            try prompt_obj.put(self.allocator, "name", .{ .string = entry.value_ptr.name });
             if (entry.value_ptr.description) |desc| {
-                try prompt_obj.put("description", .{ .string = desc });
+                try prompt_obj.put(self.allocator, "description", .{ .string = desc });
             }
             if (entry.value_ptr.title) |t| {
-                try prompt_obj.put("title", .{ .string = t });
+                try prompt_obj.put(self.allocator, "title", .{ .string = t });
             }
 
             if (entry.value_ptr.arguments) |args| {
                 var args_array = std.json.Array.init(self.allocator);
                 for (args) |arg| {
-                    var arg_obj = std.json.ObjectMap.init(self.allocator);
-                    try arg_obj.put("name", .{ .string = arg.name });
+                    var arg_obj: std.json.ObjectMap = .empty;
+                    try arg_obj.put(self.allocator, "name", .{ .string = arg.name });
                     if (arg.title) |t| {
-                        try arg_obj.put("title", .{ .string = t });
+                        try arg_obj.put(self.allocator, "title", .{ .string = t });
                     }
                     if (arg.description) |d| {
-                        try arg_obj.put("description", .{ .string = d });
+                        try arg_obj.put(self.allocator, "description", .{ .string = d });
                     }
-                    try arg_obj.put("required", .{ .bool = arg.required });
+                    try arg_obj.put(self.allocator, "required", .{ .bool = arg.required });
                     try args_array.append(.{ .object = arg_obj });
                 }
-                try prompt_obj.put("arguments", .{ .array = args_array });
+                try prompt_obj.put(self.allocator, "arguments", .{ .array = args_array });
             }
 
             try prompts_array.append(.{ .object = prompt_obj });
         }
 
-        var result = std.json.ObjectMap.init(self.allocator);
-        try result.put("prompts", .{ .array = prompts_array });
+        var result: std.json.ObjectMap = .empty;
+        try result.put(self.allocator, "prompts", .{ .array = prompts_array });
 
         const response = jsonrpc.createResponse(request.id, .{ .object = result });
         try self.sendResponse(.{ .response = response });
@@ -906,45 +907,45 @@ pub const Server = struct {
 
             var messages_array = std.json.Array.init(self.allocator);
             for (messages) |msg| {
-                var msg_obj = std.json.ObjectMap.init(self.allocator);
-                try msg_obj.put("role", .{ .string = msg.role.toString() });
-                var content_obj = std.json.ObjectMap.init(self.allocator);
+                var msg_obj: std.json.ObjectMap = .empty;
+                try msg_obj.put(self.allocator, "role", .{ .string = msg.role.toString() });
+                var content_obj: std.json.ObjectMap = .empty;
                 switch (msg.content) {
                     .text => |text| {
-                        try content_obj.put("type", .{ .string = "text" });
-                        try content_obj.put("text", .{ .string = text.text });
+                        try content_obj.put(self.allocator, "type", .{ .string = "text" });
+                        try content_obj.put(self.allocator, "text", .{ .string = text.text });
                     },
                     .image => |img| {
-                        try content_obj.put("type", .{ .string = "image" });
-                        try content_obj.put("data", .{ .string = img.data });
-                        try content_obj.put("mimeType", .{ .string = img.mimeType });
+                        try content_obj.put(self.allocator, "type", .{ .string = "image" });
+                        try content_obj.put(self.allocator, "data", .{ .string = img.data });
+                        try content_obj.put(self.allocator, "mimeType", .{ .string = img.mimeType });
                     },
                     .audio => |aud| {
-                        try content_obj.put("type", .{ .string = "audio" });
-                        try content_obj.put("data", .{ .string = aud.data });
-                        try content_obj.put("mimeType", .{ .string = aud.mimeType });
+                        try content_obj.put(self.allocator, "type", .{ .string = "audio" });
+                        try content_obj.put(self.allocator, "data", .{ .string = aud.data });
+                        try content_obj.put(self.allocator, "mimeType", .{ .string = aud.mimeType });
                     },
                     .resource_link => |link| {
-                        try content_obj.put("type", .{ .string = "resource_link" });
-                        try content_obj.put("uri", .{ .string = link.uri });
-                        try content_obj.put("name", .{ .string = link.name });
+                        try content_obj.put(self.allocator, "type", .{ .string = "resource_link" });
+                        try content_obj.put(self.allocator, "uri", .{ .string = link.uri });
+                        try content_obj.put(self.allocator, "name", .{ .string = link.name });
                     },
                     .resource => |res| {
-                        try content_obj.put("type", .{ .string = "resource" });
-                        var res_inner = std.json.ObjectMap.init(self.allocator);
-                        try res_inner.put("uri", .{ .string = res.resource.uri });
-                        if (res.resource.text) |text| try res_inner.put("text", .{ .string = text });
-                        try content_obj.put("resource", .{ .object = res_inner });
+                        try content_obj.put(self.allocator, "type", .{ .string = "resource" });
+                        var res_inner: std.json.ObjectMap = .empty;
+                        try res_inner.put(self.allocator, "uri", .{ .string = res.resource.uri });
+                        if (res.resource.text) |text| try res_inner.put(self.allocator, "text", .{ .string = text });
+                        try content_obj.put(self.allocator, "resource", .{ .object = res_inner });
                     },
                 }
-                try msg_obj.put("content", .{ .object = content_obj });
+                try msg_obj.put(self.allocator, "content", .{ .object = content_obj });
                 try messages_array.append(.{ .object = msg_obj });
             }
 
-            var result = std.json.ObjectMap.init(self.allocator);
-            try result.put("messages", .{ .array = messages_array });
+            var result: std.json.ObjectMap = .empty;
+            try result.put(self.allocator, "messages", .{ .array = messages_array });
             if (prompt.description) |desc| {
-                try result.put("description", .{ .string = desc });
+                try result.put(self.allocator, "description", .{ .string = desc });
             }
 
             const response = jsonrpc.createResponse(request.id, .{ .object = result });
@@ -984,20 +985,20 @@ pub const Server = struct {
             }
         }
 
-        const result = std.json.ObjectMap.init(self.allocator);
+        const result: std.json.ObjectMap = .empty;
         const response = jsonrpc.createResponse(request.id, .{ .object = result });
         try self.sendResponse(.{ .response = response });
     }
 
     /// Handle completion/complete request
     fn handleCompletion(self: *Self, request: jsonrpc.Request) !void {
-        var completion = std.json.ObjectMap.init(self.allocator);
+        var completion: std.json.ObjectMap = .empty;
         const values_array = std.json.Array.init(self.allocator);
-        try completion.put("values", .{ .array = values_array });
-        try completion.put("hasMore", .{ .bool = false });
+        try completion.put(self.allocator, "values", .{ .array = values_array });
+        try completion.put(self.allocator, "hasMore", .{ .bool = false });
 
-        var result = std.json.ObjectMap.init(self.allocator);
-        try result.put("completion", .{ .object = completion });
+        var result: std.json.ObjectMap = .empty;
+        try result.put(self.allocator, "completion", .{ .object = completion });
 
         const response = jsonrpc.createResponse(request.id, .{ .object = result });
         try self.sendResponse(.{ .response = response });
@@ -1019,9 +1020,9 @@ pub const Server = struct {
 
     /// Handle tasks/list request
     fn handleTasksList(self: *Self, request: jsonrpc.Request) !void {
-        var result = std.json.ObjectMap.init(self.allocator);
+        var result: std.json.ObjectMap = .empty;
         const tasks_array = std.json.Array.init(self.allocator);
-        try result.put("tasks", .{ .array = tasks_array });
+        try result.put(self.allocator, "tasks", .{ .array = tasks_array });
 
         const response = jsonrpc.createResponse(request.id, .{ .object = result });
         try self.sendResponse(.{ .response = response });
@@ -1083,23 +1084,23 @@ pub const Server = struct {
     pub fn sendLogMessage(self: *Self, level: protocol.LogLevel, message: []const u8) !void {
         if (@intFromEnum(level) < @intFromEnum(self.log_level)) return;
 
-        var params = std.json.ObjectMap.init(self.allocator);
-        try params.put("level", .{ .string = level.toString() });
-        try params.put("data", .{ .string = message });
+        var params: std.json.ObjectMap = .empty;
+        try params.put(self.allocator, "level", .{ .string = level.toString() });
+        try params.put(self.allocator, "data", .{ .string = message });
 
         try self.sendNotification("notifications/message", .{ .object = params });
     }
 
     /// Send a progress notification
     pub fn sendProgress(self: *Self, token: std.json.Value, prog: f64, total: ?f64, message: ?[]const u8) !void {
-        var params = std.json.ObjectMap.init(self.allocator);
-        try params.put("progressToken", token);
-        try params.put("progress", .{ .float = prog });
+        var params: std.json.ObjectMap = .empty;
+        try params.put(self.allocator, "progressToken", token);
+        try params.put(self.allocator, "progress", .{ .float = prog });
         if (total) |t| {
-            try params.put("total", .{ .float = t });
+            try params.put(self.allocator, "total", .{ .float = t });
         }
         if (message) |m| {
-            try params.put("message", .{ .string = m });
+            try params.put(self.allocator, "message", .{ .string = m });
         }
         try self.sendNotification("notifications/progress", .{ .object = params });
     }
@@ -1116,8 +1117,8 @@ pub const Server = struct {
 
     /// Notify clients that a resource has been updated
     pub fn notifyResourceUpdated(self: *Self, uri: []const u8) !void {
-        var params = std.json.ObjectMap.init(self.allocator);
-        try params.put("uri", .{ .string = uri });
+        var params: std.json.ObjectMap = .empty;
+        try params.put(self.allocator, "uri", .{ .string = uri });
         try self.sendNotification("notifications/resources/updated", .{ .object = params });
     }
 

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -632,7 +632,7 @@ pub const Server = struct {
         }
 
         if (self.tools.get(tool_name)) |tool| {
-            const tool_result = tool.handler(allocator, arguments) catch |err| {
+            const tool_result = tool.handler(tool.user_data, io, allocator, arguments) catch |err| {
                 var content_array: std.json.Array = .init(allocator);
                 var text_obj: std.json.ObjectMap = .empty;
                 try text_obj.put(allocator, "type", .{ .string = "text" });
@@ -747,7 +747,7 @@ pub const Server = struct {
         }
 
         if (self.resources.get(uri)) |resource| {
-            const content = resource.handler(allocator, uri) catch |err| {
+            const content = resource.handler(resource.user_data, io, allocator, uri) catch |err| {
                 const error_response = jsonrpc.createInternalError(request.id, .{ .string = @errorName(err) });
                 try self.sendResponse(io, allocator, .{ .error_response = error_response });
                 return;
@@ -883,7 +883,7 @@ pub const Server = struct {
         }
 
         if (self.prompts.get(prompt_name)) |prompt| {
-            const messages = prompt.handler(allocator, arguments) catch |err| {
+            const messages = prompt.handler(prompt.user_data, io, allocator, arguments) catch |err| {
                 const error_response = jsonrpc.createInternalError(request.id, .{ .string = @errorName(err) });
                 try self.sendResponse(io, allocator, .{ .error_response = error_response });
                 return;
@@ -1163,7 +1163,7 @@ test "Server add tool" {
         .name = "test_tool",
         .description = "A test tool",
         .handler = struct {
-            fn handler(_: std.mem.Allocator, _: ?std.json.Value) !tools_mod.ToolResult {
+            fn handler(_: ?*anyopaque, _: std.Io, _: std.mem.Allocator, _: ?std.json.Value) !tools_mod.ToolResult {
                 return .{ .content = &.{} };
             }
         }.handler,
@@ -1185,7 +1185,7 @@ test "Server add resource" {
         .uri = "file:///test",
         .name = "Test",
         .handler = struct {
-            fn handler(_: std.mem.Allocator, uri: []const u8) !resources_mod.ResourceContent {
+            fn handler(_: ?*anyopaque, _: std.Io, _: std.mem.Allocator, uri: []const u8) !resources_mod.ResourceContent {
                 return .{ .uri = uri };
             }
         }.handler,
@@ -1205,7 +1205,7 @@ test "Server add prompt" {
         .name = "test_prompt",
         .description = "A test prompt",
         .handler = struct {
-            fn handler(_: std.mem.Allocator, _: ?std.json.Value) ![]const prompts_mod.PromptMessage {
+            fn handler(_: ?*anyopaque, _: std.Io, _: std.mem.Allocator, _: ?std.json.Value) ![]const prompts_mod.PromptMessage {
                 return &.{};
             }
         }.handler,

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -140,11 +140,11 @@ pub const Server = struct {
             .config = config,
             .allocator = allocator,
             .io = io,
-            .tools = std.StringHashMap(tools_mod.Tool).init(allocator),
-            .resources = std.StringHashMap(resources_mod.Resource).init(allocator),
-            .resource_templates = std.StringHashMap(resources_mod.ResourceTemplate).init(allocator),
-            .prompts = std.StringHashMap(prompts_mod.Prompt).init(allocator),
-            .pending_requests = std.AutoHashMap(i64, PendingRequest).init(allocator),
+            .tools = .init(allocator),
+            .resources = .init(allocator),
+            .resource_templates = .init(allocator),
+            .prompts = .init(allocator),
+            .pending_requests = .init(allocator),
         };
     }
 
@@ -228,7 +228,7 @@ pub const Server = struct {
             .stdio => {
                 self.log("Server listening on STDIO");
                 const stdio = try self.allocator.create(transport_mod.StdioTransport);
-                stdio.* = transport_mod.StdioTransport.init(self.io, self.allocator);
+                stdio.* = .init(self.io, self.allocator);
                 self.stdio_transport = stdio;
                 self.transport = stdio.transport();
                 try self.messageLoop();
@@ -352,7 +352,7 @@ pub const Server = struct {
         };
         defer self.allocator.free(body_items);
 
-        var request_transport = HttpRequestTransport.init(self.allocator);
+        var request_transport: HttpRequestTransport = .init(self.allocator);
         defer request_transport.deinit();
 
         const previous_transport = self.transport;
@@ -593,7 +593,7 @@ pub const Server = struct {
 
     /// Handle tools/list request
     fn handleToolsList(self: *Self, request: jsonrpc.Request) !void {
-        var tools_array = std.json.Array.init(self.allocator);
+        var tools_array: std.json.Array = .init(self.allocator);
 
         var iter = self.tools.iterator();
         while (iter.next()) |entry| {
@@ -656,7 +656,7 @@ pub const Server = struct {
 
         if (self.tools.get(tool_name)) |tool| {
             const tool_result = tool.handler(self.allocator, arguments) catch |err| {
-                var content_array = std.json.Array.init(self.allocator);
+                var content_array: std.json.Array = .init(self.allocator);
                 var text_obj: std.json.ObjectMap = .empty;
                 try text_obj.put(self.allocator, "type", .{ .string = "text" });
                 try text_obj.put(self.allocator, "text", .{ .string = @errorName(err) });
@@ -671,7 +671,7 @@ pub const Server = struct {
                 return;
             };
 
-            var content_array = std.json.Array.init(self.allocator);
+            var content_array: std.json.Array = .init(self.allocator);
             for (tool_result.content) |content_item| {
                 var item_obj: std.json.ObjectMap = .empty;
                 switch (content_item) {
@@ -726,7 +726,7 @@ pub const Server = struct {
 
     /// Handle resources/list request
     fn handleResourcesList(self: *Self, request: jsonrpc.Request) !void {
-        var resources_array = std.json.Array.init(self.allocator);
+        var resources_array: std.json.Array = .init(self.allocator);
 
         var iter = self.resources.iterator();
         while (iter.next()) |entry| {
@@ -776,7 +776,7 @@ pub const Server = struct {
                 return;
             };
 
-            var contents_array = std.json.Array.init(self.allocator);
+            var contents_array: std.json.Array = .init(self.allocator);
             var content_obj: std.json.ObjectMap = .empty;
             try content_obj.put(self.allocator, "uri", .{ .string = uri });
             if (content.text) |text| {
@@ -803,7 +803,7 @@ pub const Server = struct {
 
     /// Handle resources/templates/list request
     fn handleResourceTemplatesList(self: *Self, request: jsonrpc.Request) !void {
-        var templates_array = std.json.Array.init(self.allocator);
+        var templates_array: std.json.Array = .init(self.allocator);
 
         var iter = self.resource_templates.iterator();
         while (iter.next()) |entry| {
@@ -849,7 +849,7 @@ pub const Server = struct {
 
     /// Handle prompts/list request
     fn handlePromptsList(self: *Self, request: jsonrpc.Request) !void {
-        var prompts_array = std.json.Array.init(self.allocator);
+        var prompts_array: std.json.Array = .init(self.allocator);
 
         var iter = self.prompts.iterator();
         while (iter.next()) |entry| {
@@ -863,7 +863,7 @@ pub const Server = struct {
             }
 
             if (entry.value_ptr.arguments) |args| {
-                var args_array = std.json.Array.init(self.allocator);
+                var args_array: std.json.Array = .init(self.allocator);
                 for (args) |arg| {
                     var arg_obj: std.json.ObjectMap = .empty;
                     try arg_obj.put(self.allocator, "name", .{ .string = arg.name });
@@ -912,7 +912,7 @@ pub const Server = struct {
                 return;
             };
 
-            var messages_array = std.json.Array.init(self.allocator);
+            var messages_array: std.json.Array = .init(self.allocator);
             for (messages) |msg| {
                 var msg_obj: std.json.ObjectMap = .empty;
                 try msg_obj.put(self.allocator, "role", .{ .string = msg.role.toString() });
@@ -1000,7 +1000,7 @@ pub const Server = struct {
     /// Handle completion/complete request
     fn handleCompletion(self: *Self, request: jsonrpc.Request) !void {
         var completion: std.json.ObjectMap = .empty;
-        const values_array = std.json.Array.init(self.allocator);
+        const values_array: std.json.Array = .init(self.allocator);
         try completion.put(self.allocator, "values", .{ .array = values_array });
         try completion.put(self.allocator, "hasMore", .{ .bool = false });
 
@@ -1028,7 +1028,7 @@ pub const Server = struct {
     /// Handle tasks/list request
     fn handleTasksList(self: *Self, request: jsonrpc.Request) !void {
         var result: std.json.ObjectMap = .empty;
-        const tasks_array = std.json.Array.init(self.allocator);
+        const tasks_array: std.json.Array = .init(self.allocator);
         try result.put(self.allocator, "tasks", .{ .array = tasks_array });
 
         const response = jsonrpc.createResponse(request.id, .{ .object = result });
@@ -1165,7 +1165,7 @@ pub const Server = struct {
 };
 
 test "Server initialization" {
-    var server = Server.init(.{
+    var server: Server = .init(.{
         .name = "test-server",
         .version = "1.0.0",
         .allocator = std.testing.allocator,
@@ -1177,14 +1177,14 @@ test "Server initialization" {
 }
 
 test "Server add tool" {
-    var server = Server.init(.{
+    var server: Server = .init(.{
         .name = "test-server",
         .version = "1.0.0",
         .allocator = std.testing.allocator,
     });
     defer server.deinit();
 
-    const tool = tools_mod.Tool{
+    const tool: tools_mod.Tool = .{
         .name = "test_tool",
         .description = "A test tool",
         .handler = struct {
@@ -1200,7 +1200,7 @@ test "Server add tool" {
 }
 
 test "Server add resource" {
-    var server = Server.init(.{
+    var server: Server = .init(.{
         .name = "test-server",
         .version = "1.0.0",
         .allocator = std.testing.allocator,
@@ -1221,7 +1221,7 @@ test "Server add resource" {
 }
 
 test "Server add prompt" {
-    var server = Server.init(.{
+    var server: Server = .init(.{
         .name = "test-server",
         .version = "1.0.0",
         .allocator = std.testing.allocator,
@@ -1242,7 +1242,7 @@ test "Server add prompt" {
 }
 
 test "Server enable capabilities" {
-    var server = Server.init(.{
+    var server: Server = .init(.{
         .name = "test-server",
         .version = "1.0.0",
         .allocator = std.testing.allocator,

--- a/src/server/tools.zig
+++ b/src/server/tools.zig
@@ -5,9 +5,10 @@
 //! API calls, calculations, or any other server-side operations.
 
 const std = @import("std");
-const types = @import("../protocol/types.zig");
-const schema = @import("../protocol/schema.zig");
+
 const jsonrpc = @import("../protocol/jsonrpc.zig");
+const schema = @import("../protocol/schema.zig");
+const types = @import("../protocol/types.zig");
 
 /// A tool that can be exposed by an MCP server.
 pub const Tool = struct {
@@ -186,7 +187,7 @@ pub fn resourceLinkResult(allocator: std.mem.Allocator, name: []const u8, uri: [
 
 /// Creates a tool result with structured JSON content and a text fallback.
 pub fn structuredResult(allocator: std.mem.Allocator, structured: std.json.Value) !ToolResult {
-    var out: std.ArrayList(u8) = .{};
+    var out: std.ArrayList(u8) = .empty;
     defer out.deinit(allocator);
     try jsonrpc.serializeValue(allocator, &out, structured);
     const text_json = try out.toOwnedSlice(allocator);

--- a/src/server/tools.zig
+++ b/src/server/tools.zig
@@ -339,13 +339,13 @@ test "isValidToolName" {
 test "argument extraction" {
     const allocator = std.testing.allocator;
 
-    var obj = std.json.ObjectMap.init(allocator);
-    defer obj.deinit();
+    var obj: std.json.ObjectMap = .empty;
+    defer obj.deinit(allocator);
 
-    try obj.put("name", .{ .string = "test" });
-    try obj.put("count", .{ .integer = 42 });
-    try obj.put("enabled", .{ .bool = true });
-    try obj.put("value", .{ .float = 3.14 });
+    try obj.put(allocator, "name", .{ .string = "test" });
+    try obj.put(allocator, "count", .{ .integer = 42 });
+    try obj.put(allocator, "enabled", .{ .bool = true });
+    try obj.put(allocator, "value", .{ .float = 3.14 });
 
     const value = std.json.Value{ .object = obj };
 

--- a/src/server/tools.zig
+++ b/src/server/tools.zig
@@ -300,7 +300,7 @@ pub fn isValidToolName(name: []const u8) bool {
 test "ToolBuilder" {
     const allocator = std.testing.allocator;
 
-    var builder = ToolBuilder.init(allocator, "test_tool");
+    var builder: ToolBuilder = .init(allocator, "test_tool");
     const tool = builder
         .description("A test tool")
         .title("Test Tool")
@@ -315,7 +315,7 @@ test "ToolBuilder" {
 test "ToolBuilder with task support" {
     const allocator = std.testing.allocator;
 
-    var builder = ToolBuilder.init(allocator, "long_tool");
+    var builder: ToolBuilder = .init(allocator, "long_tool");
     const tool = builder
         .description("A long-running tool")
         .taskSupport("optional")
@@ -347,7 +347,7 @@ test "argument extraction" {
     try obj.put(allocator, "enabled", .{ .bool = true });
     try obj.put(allocator, "value", .{ .float = 3.14 });
 
-    const value = std.json.Value{ .object = obj };
+    const value: std.json.Value = .{ .object = obj };
 
     try std.testing.expectEqualStrings("test", getString(value, "name").?);
     try std.testing.expectEqual(@as(i64, 42), getInteger(value, "count").?);

--- a/src/server/tools.zig
+++ b/src/server/tools.zig
@@ -59,16 +59,14 @@ pub const ToolError = error{
 
 /// Builder for creating tools with a fluent API.
 pub const ToolBuilder = struct {
-    allocator: std.mem.Allocator,
     tool: Tool,
     input_builder: ?schema.InputSchemaBuilder = null,
 
     const Self = @This();
 
     /// Creates a new tool builder with the given name.
-    pub fn init(allocator: std.mem.Allocator, name: []const u8) Self {
+    pub fn init(name: []const u8) Self {
         return .{
-            .allocator = allocator,
             .tool = .{
                 .name = name,
                 .handler = defaultHandler,
@@ -298,9 +296,7 @@ pub fn isValidToolName(name: []const u8) bool {
 }
 
 test "ToolBuilder" {
-    const allocator = std.testing.allocator;
-
-    var builder: ToolBuilder = .init(allocator, "test_tool");
+    var builder: ToolBuilder = .init("test_tool");
     const tool = builder
         .description("A test tool")
         .title("Test Tool")
@@ -313,9 +309,7 @@ test "ToolBuilder" {
 }
 
 test "ToolBuilder with task support" {
-    const allocator = std.testing.allocator;
-
-    var builder: ToolBuilder = .init(allocator, "long_tool");
+    var builder: ToolBuilder = .init("long_tool");
     const tool = builder
         .description("A long-running tool")
         .taskSupport("optional")

--- a/src/server/tools.zig
+++ b/src/server/tools.zig
@@ -149,15 +149,28 @@ pub fn textResult(allocator: std.mem.Allocator, text: []const u8) !ToolResult {
     const owned_text = try allocator.dupe(u8, text);
     const content = try allocator.alloc(types.ContentBlock, 1);
     content[0] = .{ .text = .{ .text = owned_text } };
-    return .{ .content = content };
+
+    var obj: std.json.ObjectMap = .empty;
+    try obj.put(allocator, "text", .{ .string = owned_text });
+
+    return .{
+        .content = content,
+        .structuredContent = .{ .object = obj },
+    };
 }
 
 /// Creates an error result containing a message.
 pub fn errorResult(allocator: std.mem.Allocator, message: []const u8) !ToolResult {
+    const owned_message = try allocator.dupe(u8, message);
     const content = try allocator.alloc(types.ContentBlock, 1);
-    content[0] = .{ .text = .{ .text = message } };
+    content[0] = .{ .text = .{ .text = owned_message } };
+
+    var obj: std.json.ObjectMap = .empty;
+    try obj.put(allocator, "error", .{ .string = owned_message });
+
     return .{
         .content = content,
+        .structuredContent = .{ .object = obj },
         .is_error = true,
     };
 }

--- a/src/server/tools.zig
+++ b/src/server/tools.zig
@@ -20,7 +20,7 @@ pub const Tool = struct {
     execution: ?types.ToolExecution = null,
     icons: ?[]const types.Icon = null,
     annotations: ?ToolAnnotations = null,
-    handler: *const fn (allocator: std.mem.Allocator, arguments: ?std.json.Value) ToolError!ToolResult,
+    handler: *const fn (user_data: ?*anyopaque, io: std.Io, allocator: std.mem.Allocator, arguments: ?std.json.Value) ToolError!ToolResult,
     user_data: ?*anyopaque = null,
 };
 
@@ -87,7 +87,7 @@ pub const ToolBuilder = struct {
     }
 
     /// Sets the tool handler function.
-    pub fn handler(self: *Self, h: *const fn (std.mem.Allocator, ?std.json.Value) ToolError!ToolResult) *Self {
+    pub fn handler(self: *Self, h: *const fn (?*anyopaque, std.Io, std.mem.Allocator, ?std.json.Value) ToolError!ToolResult) *Self {
         self.tool.handler = h;
         return self;
     }
@@ -139,7 +139,7 @@ pub const ToolBuilder = struct {
         return self.tool;
     }
 
-    fn defaultHandler(_: std.mem.Allocator, _: ?std.json.Value) ToolError!ToolResult {
+    fn defaultHandler(_: ?*anyopaque, _: std.Io, _: std.mem.Allocator, _: ?std.json.Value) ToolError!ToolResult {
         return .{ .content = &.{} };
     }
 };

--- a/src/transport/transport.zig
+++ b/src/transport/transport.zig
@@ -16,8 +16,8 @@ pub const Transport = struct {
     vtable: *const VTable,
 
     pub const VTable = struct {
-        send: *const fn (ptr: *anyopaque, message: []const u8) SendError!void,
-        receive: *const fn (ptr: *anyopaque) ReceiveError!?[]const u8,
+        send: *const fn (ptr: *anyopaque, io: std.Io, allocator: std.mem.Allocator, message: []const u8) SendError!void,
+        receive: *const fn (ptr: *anyopaque, io: std.Io, allocator: std.mem.Allocator) ReceiveError!?[]const u8,
         close: *const fn (ptr: *anyopaque) void,
     };
 
@@ -36,13 +36,13 @@ pub const Transport = struct {
     };
 
     /// Sends a message through the transport.
-    pub fn send(self: Transport, message: []const u8) SendError!void {
-        return self.vtable.send(self.ptr, message);
+    pub fn send(self: Transport, io: std.Io, allocator: std.mem.Allocator, message: []const u8) SendError!void {
+        return self.vtable.send(self.ptr, io, allocator, message);
     }
 
     /// Receives a message from the transport (blocking).
-    pub fn receive(self: Transport) ReceiveError!?[]const u8 {
-        return self.vtable.receive(self.ptr);
+    pub fn receive(self: Transport, io: std.Io, allocator: std.mem.Allocator) ReceiveError!?[]const u8 {
+        return self.vtable.receive(self.ptr, io, allocator);
     }
 
     /// Closes the transport connection.
@@ -54,46 +54,35 @@ pub const Transport = struct {
 /// STDIO transport for local process communication.
 /// Messages are delimited by newlines and sent via stdin/stdout.
 pub const StdioTransport = struct {
-    allocator: std.mem.Allocator,
-    io: std.Io,
-    read_buffer: std.ArrayList(u8),
+    read_buffer: std.ArrayList(u8) = .empty,
     is_closed: bool = false,
     max_message_size: usize = 4 * 1024 * 1024,
 
     const Self = @This();
 
-    /// Initializes a new STDIO transport.
-    pub fn init(io: std.Io, allocator: std.mem.Allocator) Self {
-        return .{
-            .allocator = allocator,
-            .io = io,
-            .read_buffer = .empty,
-        };
-    }
-
     /// Releases resources held by the transport.
-    pub fn deinit(self: *Self) void {
-        self.read_buffer.deinit(self.allocator);
+    pub fn deinit(self: *Self, allocator: std.mem.Allocator) void {
+        self.read_buffer.deinit(allocator);
     }
 
     /// Sends a JSON-RPC message to stdout with newline delimiter.
-    pub fn send(self: *Self, message: []const u8) Transport.SendError!void {
+    pub fn send(self: *Self, io: std.Io, _: std.mem.Allocator, message: []const u8) Transport.SendError!void {
         if (self.is_closed) return Transport.SendError.ConnectionClosed;
 
         const stdout = std.Io.File.stdout();
-        stdout.writeStreamingAll(self.io, message) catch return Transport.SendError.WriteError;
-        stdout.writeStreamingAll(self.io, "\n") catch return Transport.SendError.WriteError;
+        stdout.writeStreamingAll(io, message) catch return Transport.SendError.WriteError;
+        stdout.writeStreamingAll(io, "\n") catch return Transport.SendError.WriteError;
     }
 
     /// Sends a JSON-RPC message object.
-    pub fn sendMessage(self: *Self, message: jsonrpc.Message) !void {
-        const json = try jsonrpc.serializeMessage(self.allocator, message);
-        defer self.allocator.free(json);
-        try self.send(json);
+    pub fn sendMessage(self: *Self, io: std.Io, allocator: std.mem.Allocator, message: jsonrpc.Message) !void {
+        const json = try jsonrpc.serializeMessage(allocator, message);
+        defer allocator.free(json);
+        try self.send(io, allocator, json);
     }
 
     /// Receives a JSON-RPC message from stdin (reads until newline).
-    pub fn receive(self: *Self) Transport.ReceiveError!?[]const u8 {
+    pub fn receive(self: *Self, io: std.Io, allocator: std.mem.Allocator) Transport.ReceiveError!?[]const u8 {
         if (self.is_closed) return Transport.ReceiveError.ConnectionClosed;
 
         self.read_buffer.clearRetainingCapacity();
@@ -102,7 +91,7 @@ pub const StdioTransport = struct {
 
         while (true) {
             var buf: [1]u8 = undefined;
-            const bytes_read = stdin.readStreaming(self.io, &.{&buf}) catch return Transport.ReceiveError.ReadError;
+            const bytes_read = stdin.readStreaming(io, &.{&buf}) catch return Transport.ReceiveError.ReadError;
 
             if (bytes_read == 0) {
                 if (self.read_buffer.items.len == 0) {
@@ -120,14 +109,14 @@ pub const StdioTransport = struct {
                 return Transport.ReceiveError.MessageTooLarge;
             }
 
-            self.read_buffer.append(self.allocator, byte) catch return Transport.ReceiveError.OutOfMemory;
+            self.read_buffer.append(allocator, byte) catch return Transport.ReceiveError.OutOfMemory;
         }
 
         if (self.read_buffer.items.len == 0) {
             return null;
         }
 
-        const result = self.allocator.dupe(u8, self.read_buffer.items) catch {
+        const result = allocator.dupe(u8, self.read_buffer.items) catch {
             return Transport.ReceiveError.OutOfMemory;
         };
         return result;
@@ -139,10 +128,10 @@ pub const StdioTransport = struct {
     }
 
     /// Writes a message to stderr for logging.
-    pub fn writeStderr(self: *Self, message: []const u8) void {
+    pub fn writeStderr(_: *Self, io: std.Io, message: []const u8) void {
         const stderr = std.Io.File.stderr();
-        stderr.writeStreamingAll(self.io, message) catch {};
-        stderr.writeStreamingAll(self.io, "\n") catch {};
+        stderr.writeStreamingAll(io, message) catch {};
+        stderr.writeStreamingAll(io, "\n") catch {};
     }
 
     /// Returns a Transport interface for this STDIO transport.
@@ -157,14 +146,14 @@ pub const StdioTransport = struct {
         };
     }
 
-    fn sendVtable(ptr: *anyopaque, message: []const u8) Transport.SendError!void {
+    fn sendVtable(ptr: *anyopaque, io: std.Io, allocator: std.mem.Allocator, message: []const u8) Transport.SendError!void {
         const self: *Self = @ptrCast(@alignCast(ptr));
-        return self.send(message);
+        return self.send(io, allocator, message);
     }
 
-    fn receiveVtable(ptr: *anyopaque) Transport.ReceiveError!?[]const u8 {
+    fn receiveVtable(ptr: *anyopaque, io: std.Io, allocator: std.mem.Allocator) Transport.ReceiveError!?[]const u8 {
         const self: *Self = @ptrCast(@alignCast(ptr));
-        return self.receive();
+        return self.receive(io, allocator);
     }
 
     fn closeVtable(ptr: *anyopaque) void {
@@ -176,13 +165,12 @@ pub const StdioTransport = struct {
 /// HTTP transport for remote server communication.
 /// Sends requests via HTTP POST and receives responses.
 pub const HttpTransport = struct {
-    allocator: std.mem.Allocator,
     endpoint: []const u8,
     session_id: ?[]const u8 = null,
     authorization_token: ?[]const u8 = null,
     protocol_version: []const u8 = "2025-11-25",
     is_closed: bool = false,
-    pending_responses: std.ArrayList([]const u8),
+    pending_responses: std.ArrayList([]const u8) = .empty,
 
     const Self = @This();
 
@@ -190,63 +178,61 @@ pub const HttpTransport = struct {
     pub fn init(allocator: std.mem.Allocator, endpoint: []const u8) !Self {
         const owned_endpoint = try allocator.dupe(u8, endpoint);
         return .{
-            .allocator = allocator,
             .endpoint = owned_endpoint,
-            .pending_responses = .empty,
         };
     }
 
     /// Releases resources held by the transport.
-    pub fn deinit(self: *Self) void {
-        self.allocator.free(self.endpoint);
+    pub fn deinit(self: *Self, allocator: std.mem.Allocator) void {
+        allocator.free(self.endpoint);
         for (self.pending_responses.items) |item| {
-            self.allocator.free(item);
+            allocator.free(item);
         }
-        self.pending_responses.deinit(self.allocator);
+        self.pending_responses.deinit(allocator);
         if (self.session_id) |sid| {
-            self.allocator.free(sid);
+            allocator.free(sid);
         }
         if (self.authorization_token) |token| {
-            self.allocator.free(token);
+            allocator.free(token);
         }
     }
 
     /// Sends a JSON-RPC message via HTTP POST.
-    pub fn send(self: *Self, message: []const u8) Transport.SendError!void {
+    pub fn send(self: *Self, _: std.Io, allocator: std.mem.Allocator, message: []const u8) Transport.SendError!void {
         if (self.is_closed) return Transport.SendError.ConnectionClosed;
 
-        var client: std.http.Client = .{ .allocator = self.allocator };
+        var client: std.http.Client = .{ .allocator = allocator };
         defer client.deinit();
 
         const uri = std.Uri.parse(self.endpoint) catch return Transport.SendError.WriteError;
 
         var extra_headers: std.ArrayList(std.http.Header) = .empty;
-        defer extra_headers.deinit(self.allocator);
+        defer extra_headers.deinit(allocator);
 
-        extra_headers.append(self.allocator, .{ .name = "Content-Type", .value = "application/json" }) catch {
+        extra_headers.append(allocator, .{ .name = "Content-Type", .value = "application/json" }) catch {
             return Transport.SendError.OutOfMemory;
         };
-        extra_headers.append(self.allocator, .{ .name = "Accept", .value = "application/json" }) catch {
+        extra_headers.append(allocator, .{ .name = "Accept", .value = "application/json" }) catch {
             return Transport.SendError.OutOfMemory;
         };
-        extra_headers.append(self.allocator, .{ .name = "MCP-Protocol-Version", .value = self.protocol_version }) catch {
+        extra_headers.append(allocator, .{ .name = "MCP-Protocol-Version", .value = self.protocol_version }) catch {
             return Transport.SendError.OutOfMemory;
         };
 
         var authorization_value: ?[]u8 = null;
-        defer if (authorization_value) |owned| self.allocator.free(owned);
+        defer if (authorization_value) |owned| allocator.free(owned);
 
         if (self.authorization_token) |token| {
-            authorization_value = std.fmt.allocPrint(self.allocator, "Bearer {s}", .{token}) catch {
+            authorization_value = std.fmt.allocPrint(allocator, "Bearer {s}", .{token}) catch {
                 return Transport.SendError.OutOfMemory;
             };
-            extra_headers.append(self.allocator, .{ .name = "Authorization", .value = authorization_value.? }) catch {
+            extra_headers.append(allocator, .{ .name = "Authorization", .value = authorization_value.? }) catch {
                 return Transport.SendError.OutOfMemory;
             };
         }
 
         if (self.session_id) |sid| {
-            extra_headers.append(self.allocator, .{ .name = "MCP-Session-Id", .value = sid }) catch {
+            extra_headers.append(allocator, .{ .name = "MCP-Session-Id", .value = sid }) catch {
                 return Transport.SendError.OutOfMemory;
             };
         }
@@ -264,15 +250,15 @@ pub const HttpTransport = struct {
         body_writer.end() catch return Transport.SendError.WriteError;
         req.connection.?.flush() catch return Transport.SendError.WriteError;
 
-        const redirect_buffer = self.allocator.alloc(u8, 8 * 1024) catch return Transport.SendError.OutOfMemory;
-        defer self.allocator.free(redirect_buffer);
+        const redirect_buffer = allocator.alloc(u8, 8 * 1024) catch return Transport.SendError.OutOfMemory;
+        defer allocator.free(redirect_buffer);
 
         var response = req.receiveHead(redirect_buffer) catch return Transport.SendError.WriteError;
 
         var header_it = response.head.iterateHeaders();
         while (header_it.next()) |header| {
             if (std.ascii.eqlIgnoreCase(header.name, "mcp-session-id")) {
-                self.setSessionId(header.value) catch return Transport.SendError.OutOfMemory;
+                self.setSessionId(allocator, header.value) catch return Transport.SendError.OutOfMemory;
             }
         }
 
@@ -280,26 +266,26 @@ pub const HttpTransport = struct {
         var reader = response.reader(&transfer_buffer);
 
         var body: std.ArrayList(u8) = .empty;
-        defer body.deinit(self.allocator);
+        defer body.deinit(allocator);
 
         var buf: [4096]u8 = undefined;
         while (true) {
             const n = reader.readSliceShort(&buf) catch return Transport.SendError.WriteError;
             if (n == 0) break;
-            body.appendSlice(self.allocator, buf[0..n]) catch return Transport.SendError.OutOfMemory;
+            body.appendSlice(allocator, buf[0..n]) catch return Transport.SendError.OutOfMemory;
         }
 
         if (body.items.len == 0) return;
 
-        const owned = self.allocator.dupe(u8, body.items) catch return Transport.SendError.OutOfMemory;
-        self.pending_responses.append(self.allocator, owned) catch {
-            self.allocator.free(owned);
+        const owned = allocator.dupe(u8, body.items) catch return Transport.SendError.OutOfMemory;
+        self.pending_responses.append(allocator, owned) catch {
+            allocator.free(owned);
             return Transport.SendError.OutOfMemory;
         };
     }
 
     /// Receives a response from the pending queue.
-    pub fn receive(self: *Self) Transport.ReceiveError!?[]const u8 {
+    pub fn receive(self: *Self, _: std.Io, _: std.mem.Allocator) Transport.ReceiveError!?[]const u8 {
         if (self.is_closed) return Transport.ReceiveError.ConnectionClosed;
 
         if (self.pending_responses.items.len > 0) {
@@ -314,19 +300,19 @@ pub const HttpTransport = struct {
     }
 
     /// Sets the session ID from the MCP-Session-Id header.
-    pub fn setSessionId(self: *Self, session_id: []const u8) !void {
+    pub fn setSessionId(self: *Self, allocator: std.mem.Allocator, session_id: []const u8) !void {
         if (self.session_id) |old| {
-            self.allocator.free(old);
+            allocator.free(old);
         }
-        self.session_id = try self.allocator.dupe(u8, session_id);
+        self.session_id = try allocator.dupe(u8, session_id);
     }
 
     /// Sets the authorization token for Bearer auth (OAuth 2.1).
-    pub fn setAuthorizationToken(self: *Self, token: []const u8) !void {
+    pub fn setAuthorizationToken(self: *Self, allocator: std.mem.Allocator, token: []const u8) !void {
         if (self.authorization_token) |old| {
-            self.allocator.free(old);
+            allocator.free(old);
         }
-        self.authorization_token = try self.allocator.dupe(u8, token);
+        self.authorization_token = try allocator.dupe(u8, token);
     }
 
     /// Returns a Transport interface for this HTTP transport.
@@ -341,14 +327,14 @@ pub const HttpTransport = struct {
         };
     }
 
-    fn sendVtable(ptr: *anyopaque, message: []const u8) Transport.SendError!void {
+    fn sendVtable(ptr: *anyopaque, io: std.Io, allocator: std.mem.Allocator, message: []const u8) Transport.SendError!void {
         const self: *Self = @ptrCast(@alignCast(ptr));
-        return self.send(message);
+        return self.send(io, allocator, message);
     }
 
-    fn receiveVtable(ptr: *anyopaque) Transport.ReceiveError!?[]const u8 {
+    fn receiveVtable(ptr: *anyopaque, io: std.Io, allocator: std.mem.Allocator) Transport.ReceiveError!?[]const u8 {
         const self: *Self = @ptrCast(@alignCast(ptr));
-        return self.receive();
+        return self.receive(io, allocator);
     }
 
     fn closeVtable(ptr: *anyopaque) void {
@@ -365,25 +351,26 @@ pub const TransportType = enum {
 
 /// Creates a transport based on the specified type.
 pub fn createTransport(
-    allocator: std.mem.Allocator,
     io: std.Io,
+    allocator: std.mem.Allocator,
     transport_type: TransportType,
     options: TransportOptions,
 ) !Transport {
+    _ = io;
     switch (transport_type) {
         .stdio => {
             const stdio = try allocator.create(StdioTransport);
-            stdio.* = .init(io, allocator);
+            stdio.* = .{};
             return stdio.transport();
         },
         .http => {
             const url = options.url orelse return error.MissingUrl;
-            const http = try allocator.create(HttpTransport);
-            http.* = try .init(allocator, url);
+            const http_transport = try allocator.create(HttpTransport);
+            http_transport.* = try .init(allocator, url);
             if (options.authorization_token) |token| {
-                try http.setAuthorizationToken(token);
+                try http_transport.setAuthorizationToken(allocator, token);
             }
-            return http.transport();
+            return http_transport.transport();
         },
     }
 }
@@ -395,9 +382,8 @@ pub const TransportOptions = struct {
 };
 
 test "StdioTransport initialization" {
-    const allocator = std.testing.allocator;
-    var transport_impl: StdioTransport = .init(std.Io.failing, allocator);
-    defer transport_impl.deinit();
+    var transport_impl: StdioTransport = .{};
+    _ = &transport_impl;
 
     try std.testing.expect(!transport_impl.is_closed);
 }
@@ -405,7 +391,7 @@ test "StdioTransport initialization" {
 test "HttpTransport initialization" {
     const allocator = std.testing.allocator;
     var transport_impl = try HttpTransport.init(allocator, "http://localhost:3000");
-    defer transport_impl.deinit();
+    defer transport_impl.deinit(allocator);
 
     try std.testing.expectEqualStrings("http://localhost:3000", transport_impl.endpoint);
 }
@@ -413,8 +399,8 @@ test "HttpTransport initialization" {
 test "HttpTransport session ID" {
     const allocator = std.testing.allocator;
     var transport_impl = try HttpTransport.init(allocator, "http://localhost:3000");
-    defer transport_impl.deinit();
+    defer transport_impl.deinit(allocator);
 
-    try transport_impl.setSessionId("test-session-123");
+    try transport_impl.setSessionId(allocator, "test-session-123");
     try std.testing.expectEqualStrings("test-session-123", transport_impl.session_id.?);
 }

--- a/src/transport/transport.zig
+++ b/src/transport/transport.zig
@@ -5,6 +5,7 @@
 //! transport for remote server connections.
 
 const std = @import("std");
+
 const jsonrpc = @import("../protocol/jsonrpc.zig");
 const types = @import("../protocol/types.zig");
 
@@ -54,6 +55,7 @@ pub const Transport = struct {
 /// Messages are delimited by newlines and sent via stdin/stdout.
 pub const StdioTransport = struct {
     allocator: std.mem.Allocator,
+    io: std.Io,
     read_buffer: std.ArrayList(u8),
     is_closed: bool = false,
     max_message_size: usize = 4 * 1024 * 1024,
@@ -61,10 +63,11 @@ pub const StdioTransport = struct {
     const Self = @This();
 
     /// Initializes a new STDIO transport.
-    pub fn init(allocator: std.mem.Allocator) Self {
+    pub fn init(io: std.Io, allocator: std.mem.Allocator) Self {
         return .{
             .allocator = allocator,
-            .read_buffer = .{},
+            .io = io,
+            .read_buffer = .empty,
         };
     }
 
@@ -77,9 +80,9 @@ pub const StdioTransport = struct {
     pub fn send(self: *Self, message: []const u8) Transport.SendError!void {
         if (self.is_closed) return Transport.SendError.ConnectionClosed;
 
-        const stdout = std.fs.File.stdout();
-        stdout.writeAll(message) catch return Transport.SendError.WriteError;
-        stdout.writeAll("\n") catch return Transport.SendError.WriteError;
+        const stdout = std.Io.File.stdout();
+        stdout.writeStreamingAll(self.io, message) catch return Transport.SendError.WriteError;
+        stdout.writeStreamingAll(self.io, "\n") catch return Transport.SendError.WriteError;
     }
 
     /// Sends a JSON-RPC message object.
@@ -95,11 +98,11 @@ pub const StdioTransport = struct {
 
         self.read_buffer.clearRetainingCapacity();
 
-        const stdin = std.fs.File.stdin();
+        const stdin = std.Io.File.stdin();
 
         while (true) {
             var buf: [1]u8 = undefined;
-            const bytes_read = stdin.read(&buf) catch return Transport.ReceiveError.ReadError;
+            const bytes_read = stdin.readStreaming(self.io, &.{&buf}) catch return Transport.ReceiveError.ReadError;
 
             if (bytes_read == 0) {
                 if (self.read_buffer.items.len == 0) {
@@ -137,10 +140,9 @@ pub const StdioTransport = struct {
 
     /// Writes a message to stderr for logging.
     pub fn writeStderr(self: *Self, message: []const u8) void {
-        _ = self;
-        const stderr = std.fs.File.stderr();
-        stderr.writeAll(message) catch {};
-        stderr.writeAll("\n") catch {};
+        const stderr = std.Io.File.stderr();
+        stderr.writeStreamingAll(self.io, message) catch {};
+        stderr.writeStreamingAll(self.io, "\n") catch {};
     }
 
     /// Returns a Transport interface for this STDIO transport.
@@ -190,7 +192,7 @@ pub const HttpTransport = struct {
         return .{
             .allocator = allocator,
             .endpoint = owned_endpoint,
-            .pending_responses = .{},
+            .pending_responses = .empty,
         };
     }
 
@@ -218,7 +220,7 @@ pub const HttpTransport = struct {
 
         const uri = std.Uri.parse(self.endpoint) catch return Transport.SendError.WriteError;
 
-        var extra_headers = std.ArrayList(std.http.Header){};
+        var extra_headers: std.ArrayList(std.http.Header) = .empty;
         defer extra_headers.deinit(self.allocator);
 
         extra_headers.append(self.allocator, .{ .name = "Content-Type", .value = "application/json" }) catch {
@@ -277,15 +279,14 @@ pub const HttpTransport = struct {
         var transfer_buffer: [1024]u8 = undefined;
         var reader = response.reader(&transfer_buffer);
 
-        var body = std.ArrayList(u8){};
+        var body: std.ArrayList(u8) = .empty;
         defer body.deinit(self.allocator);
-        const writer = body.writer(self.allocator);
 
         var buf: [4096]u8 = undefined;
         while (true) {
             const n = reader.readSliceShort(&buf) catch return Transport.SendError.WriteError;
             if (n == 0) break;
-            writer.writeAll(buf[0..n]) catch return Transport.SendError.OutOfMemory;
+            body.appendSlice(self.allocator, buf[0..n]) catch return Transport.SendError.OutOfMemory;
         }
 
         if (body.items.len == 0) return;
@@ -365,19 +366,20 @@ pub const TransportType = enum {
 /// Creates a transport based on the specified type.
 pub fn createTransport(
     allocator: std.mem.Allocator,
+    io: std.Io,
     transport_type: TransportType,
     options: TransportOptions,
 ) !Transport {
     switch (transport_type) {
         .stdio => {
             const stdio = try allocator.create(StdioTransport);
-            stdio.* = StdioTransport.init(allocator);
+            stdio.* = .init(io, allocator);
             return stdio.transport();
         },
         .http => {
             const url = options.url orelse return error.MissingUrl;
             const http = try allocator.create(HttpTransport);
-            http.* = try HttpTransport.init(allocator, url);
+            http.* = try .init(allocator, url);
             if (options.authorization_token) |token| {
                 try http.setAuthorizationToken(token);
             }
@@ -394,7 +396,7 @@ pub const TransportOptions = struct {
 
 test "StdioTransport initialization" {
     const allocator = std.testing.allocator;
-    var transport_impl = StdioTransport.init(allocator);
+    var transport_impl: StdioTransport = .init(std.Io.failing, allocator);
     defer transport_impl.deinit();
 
     try std.testing.expect(!transport_impl.is_closed);

--- a/src/transport/transport.zig
+++ b/src/transport/transport.zig
@@ -215,7 +215,7 @@ pub const HttpTransport = struct {
     pub fn send(self: *Self, message: []const u8) Transport.SendError!void {
         if (self.is_closed) return Transport.SendError.ConnectionClosed;
 
-        var client = std.http.Client{ .allocator = self.allocator };
+        var client: std.http.Client = .{ .allocator = self.allocator };
         defer client.deinit();
 
         const uri = std.Uri.parse(self.endpoint) catch return Transport.SendError.WriteError;

--- a/src/utils/logging.zig
+++ b/src/utils/logging.zig
@@ -40,11 +40,10 @@ pub const Config = struct {
 /// Logger instance for structured log output.
 pub const Logger = struct {
     config: Config,
-    allocator: std.mem.Allocator,
 
     /// Creates a new logger with the given configuration.
-    pub fn init(allocator: std.mem.Allocator, config: Config) Logger {
-        return .{ .config = config, .allocator = allocator };
+    pub fn init(config: Config) Logger {
+        return .{ .config = config };
     }
 
     /// Logs a debug-level message.
@@ -80,8 +79,8 @@ pub const Logger = struct {
 var global_logger: ?Logger = null;
 
 /// Initializes the global logger with the given configuration.
-pub fn initGlobal(allocator: std.mem.Allocator, config: Config) void {
-    global_logger = Logger.init(allocator, config);
+pub fn initGlobal(config: Config) void {
+    global_logger = Logger.init(config);
 }
 
 /// Logs a debug message to the global logger.

--- a/src/utils/network.zig
+++ b/src/utils/network.zig
@@ -4,8 +4,8 @@
 //! Used primarily for update checking and logging.
 
 const std = @import("std");
-const builtin = @import("builtin");
 const http = std.http;
+const builtin = @import("builtin");
 
 pub const NetworkError = error{
     InvalidUri,
@@ -19,8 +19,11 @@ pub const NetworkError = error{
 
 /// Fetches a JSON response from a URL.
 /// Returns the parsed JSON value (caller must deinit).
-pub fn fetchJson(allocator: std.mem.Allocator, url: []const u8, headers: []const http.Header) !std.json.Parsed(std.json.Value) {
-    var client = http.Client{ .allocator = allocator };
+pub fn fetchJson(io: std.Io, allocator: std.mem.Allocator, url: []const u8, headers: []const http.Header) !std.json.Parsed(std.json.Value) {
+    var client: http.Client = .{
+        .allocator = allocator,
+        .io = io,
+    };
     defer client.deinit();
 
     var req = try client.request(.GET, try std.Uri.parse(url), .{
@@ -52,12 +55,11 @@ pub fn fetchJson(allocator: std.mem.Allocator, url: []const u8, headers: []const
     var body = std.ArrayList(u8).initCapacity(allocator, 4096) catch return NetworkError.ReadError;
     defer body.deinit(allocator);
 
-    const writer = body.writer(allocator);
     var buf: [4096]u8 = undefined;
     while (true) {
         const n = reader.readSliceShort(&buf) catch return NetworkError.ReadError;
         if (n == 0) break;
-        try writer.writeAll(buf[0..n]);
+        body.appendSlice(allocator, buf[0..n]) catch return NetworkError.ReadError;
     }
 
     // Parse JSON from the response body.

--- a/src/utils/progress.zig
+++ b/src/utils/progress.zig
@@ -74,7 +74,7 @@ pub fn createToken(allocator: std.mem.Allocator) !ProgressToken {
 }
 
 test "Tracker" {
-    var tracker = Tracker.init(.{ .integer = 1 }, 100);
+    var tracker: Tracker = .init(.{ .integer = 1 }, 100);
     try std.testing.expectEqual(@as(f64, 0), tracker.current);
 
     tracker.update(50, null);


### PR DESCRIPTION
Support zig 0.16 and the new `std.Io` interface for I/O, unmanaged `std.ArrayList` & `json.ObjectMap`, and `std.process.Init` aka "juicy main". This also makes some idiomatic improvements like moving `std.mem.Allocator` to explicit function parameters instead of fields, and using the new decl literal syntax where applicable. It also updates the handler function pointers to include the `user_data` field along with the new `std.Io` interface. All the docs, examples, and README should be updated too.