### PR TITLE
Wire Tool.inputSchema through tools/list (partial fix for #9)

### DIFF
--- a/src/protocol/schema.zig
+++ b/src/protocol/schema.zig
@@ -4,6 +4,7 @@
 //! in MCP for tool input validation and type definitions.
 
 const std = @import("std");
+const types = @import("types.zig");
 
 /// JSON Schema type definitions.
 pub const SchemaType = enum {
@@ -301,14 +302,26 @@ pub const InputSchemaBuilder = struct {
         return self;
     }
 
-    /// Builds the final input schema as a JSON value.
-    pub fn build(self: *InputSchemaBuilder, allocator: std.mem.Allocator) !std.json.Value {
-        var obj: std.json.ObjectMap = .empty;
-        errdefer obj.deinit(allocator);
+    /// Builds the final input schema as an 'InputSchema'.
+    pub fn toInputSchema(self: *InputSchemaBuilder, allocator: std.mem.Allocator) !types.InputSchema {
+        const props = try self.buildProperties(allocator);
 
-        try obj.put(allocator, "type", .{ .string = "object" });
+        const req: ?[]const []const u8 = if (self.required_fields.items.len == 0)
+            null
+        else
+            try allocator.dupe([]const u8, self.required_fields.items);
 
+        return .{
+            .type = "object",
+            .properties = if (props.count() == 0) null else .{ .object = props },
+            .required = req,
+        };
+    }
+
+    fn buildProperties(self: *InputSchemaBuilder, allocator: std.mem.Allocator) !std.json.ObjectMap {
         var props: std.json.ObjectMap = .empty;
+        errdefer props.deinit(allocator);
+
         var iter = self.properties.iterator();
         while (iter.next()) |entry| {
             var prop_obj: std.json.ObjectMap = .empty;
@@ -318,6 +331,18 @@ pub const InputSchemaBuilder = struct {
             }
             try props.put(allocator, entry.key_ptr.*, .{ .object = prop_obj });
         }
+
+        return props;
+    }
+
+    /// Builds the final input schema as a JSON value.
+    pub fn build(self: *InputSchemaBuilder, allocator: std.mem.Allocator) !std.json.Value {
+        var obj: std.json.ObjectMap = .empty;
+        errdefer obj.deinit(allocator);
+
+        try obj.put(allocator, "type", .{ .string = "object" });
+
+        const props = try self.buildProperties(allocator);
         try obj.put(allocator, "properties", .{ .object = props });
 
         if (self.required_fields.items.len > 0) {

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -601,7 +601,21 @@ pub const Server = struct {
             }
 
             var input_schema: std.json.ObjectMap = .empty;
-            try input_schema.put(allocator, "type", .{ .string = "object" });
+            if (entry.value_ptr.inputSchema) |schema| {
+                try input_schema.put(allocator, "type", .{ .string = schema.type });
+
+                if (schema.@"$schema") |s| try input_schema.put(allocator, "$schema", .{ .string = s });
+                if (schema.description) |d| try input_schema.put(allocator, "description", .{ .string = d });
+                if (schema.properties) |p| try input_schema.put(allocator, "properties", p);
+
+                if (schema.required) |req| {
+                    var arr: std.json.Array = .init(allocator);
+                    for (req) |name| try arr.append(.{ .string = name });
+                    try input_schema.put(allocator, "required", .{ .array = arr });
+                }
+            } else {
+                try input_schema.put(allocator, "type", .{ .string = "object" });
+            }
             try tool_obj.put(allocator, "inputSchema", .{ .object = input_schema });
 
             if (entry.value_ptr.annotations) |ann| {


### PR DESCRIPTION
Hey @muhammad-fiaz !

This PR closes (partially) #9.

It adds two commits, each addresses one of the two problems outlined in the issue:

- Serialize `Tool.inputSchema` in tools/list response: `handleToolsList` now serializes a tool's `inputSchema` fields into the response instead of always emitting `{"type":"object"}`. Falls back to the hardcoded stub when `inputSchema` is null. This alone unblocks downstream users.

-  Add `InputSchemaBuilder.toInputSchema` for typed schema:  Adds `InputSchemaBuilder.toInputSchema(allocator)` which returns a typed `types.InputSchema`, complementing the existing `build()` which returns a raw `std.json.Value`. A small private `buildProperties` helper is shared by both paths to avoid duplication. `build()` is left untouched for backward compatibility.

This is a "partial" fix in the sense that there is still the old `InputSchemaBuilder.build` which realistically cannot be used for anything useful, but at least now we can do:

```zig
var webSearchSchema = mcp.schema.InputSchemaBuilder.init(alloc);
defer webSearchSchema.deinit(alloc);
_ = try webSearchSchema.addString(alloc, "query", "The query to send to the web api", true);

try server.addTool(.{
    .name = "web_search",
    .description = "Search the web for news or anything else interesting",
    .handler = webSearchHandler,
    .inputSchema = try webSearchSchema.toInputSchema(alloc),
});
```

If you prefer to take another direction as far as the library design goes, let me know!